### PR TITLE
Autofocus First Field on Form Pages

### DIFF
--- a/src/routes/forgot_password/+page.svelte
+++ b/src/routes/forgot_password/+page.svelte
@@ -39,6 +39,7 @@
       placeholder="Email"
       class="form-control"
       required
+      autofocus
     />
   </div>
   <button type="submit" class="btn">Send reset link</button>

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -40,7 +40,7 @@
 <h1>{data.audio.title}</h1>
 
 <div class="audio-player">
-    <audio controls id="player" on:play={handlePlay}>
+    <audio controls id="player" on:play={handlePlay} autofocus>
         <source src="/{data.audio.path}" type={data.mimeType} />
         <source src="/{data.audio.transcodedPath}" type="audio/aac" />
         <p>Your browser doesn't support the audio element.</p>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -43,6 +43,7 @@
             id="email"
             name="email"
             required
+            autofocus
             class="form-control"
         />
     </div>

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -43,6 +43,7 @@
             id="username"
             name="username"
             required
+            autofocus
             minlength="3"
             maxlength="24"
             class="form-control"

--- a/src/routes/reset_password/[token]/+page.svelte
+++ b/src/routes/reset_password/[token]/+page.svelte
@@ -52,6 +52,7 @@
             minlength="8"
             maxlength="64"
             required
+            autofocus
         />
     </div>
     <button type="submit" class="btn">Reset password</button>

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -44,6 +44,7 @@
             id="title"
             name="title"
             required
+            autofocus
             minlength="3"
             maxlength="120"
             class="form-control"

--- a/src/routes/verify/+page.svelte
+++ b/src/routes/verify/+page.svelte
@@ -49,6 +49,7 @@
             name="token"
             placeholder="Verification token"
             class="form-control"
+            autofocus
         />
     </div>
     <button type="submit" class="btn">Verify</button>


### PR DESCRIPTION
This speeds up site usage for many pages primarily designed for form entry (login, register, upload, etc).

Also focus the audio player on /listen/[token] page load (this might be contravercial).