### PR TITLE
Don't use use:enhance on search form

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -135,7 +135,7 @@
             <a href="/register">Register</a>
         {/if}
     </nav>
-    <form use:enhance action="/search" method="get">
+    <form action="/search" method="get">
         <input type="text" name="q" placeholder="Search..." />
         <button type="submit">Search</button>
     </form>


### PR DESCRIPTION
The search form has method="get", so it is incompatible with use:enhance. Using it anyway was causing all other use:enhances to fail.

Figured this out while implementing threaded comments, fixing this makes them significantly nicer to use in modern browsers.