### PR TITLE
Threaded Comments

### DIFF
--- a/src/lib/components/comment.svelte
+++ b/src/lib/components/comment.svelte
@@ -72,7 +72,13 @@
         <pre>{comment.content}</pre>
         <button on:click={() => (isDeletionModalVisible = false)}>Cancel</button
         >
-        <form use:enhance action="?/delete_comment" method="post">
+        <form action="?/delete_comment" method="post"
+        use:enhance={() => {
+          return async ({ update }) => {
+            await update();
+            isDeletionModalVisible = false; // close modal after deletion
+          };
+        }}>
           <input type="hidden" name="id" value={comment.id} />
           <button type="submit">Confirm delete</button>
         </form>

--- a/src/lib/components/comment.svelte
+++ b/src/lib/components/comment.svelte
@@ -23,6 +23,7 @@
   import { enhance } from "$app/forms";
   import SafeMarkdown from "./safe_markdown.svelte";
   import { updated } from "$app/state";
+  import CommentList from "./comment_list.svelte";
 
   export let comment: ClientsideComment;
   export let user: ClientsideUser | undefined = undefined;
@@ -79,6 +80,10 @@
     {/if}
   </div>
 </div>
+
+{#if comment.replies}
+<CommentList comments={comment.replies} {user} {isAdmin} {onReply} label="Replies" />
+{/if}
 
 <style>
   .comment {

--- a/src/lib/components/comment.svelte
+++ b/src/lib/components/comment.svelte
@@ -17,83 +17,105 @@
   along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <script lang="ts">
-    import { formatRelative } from "date-fns";
-    import type { ClientsideComment, ClientsideUser } from "$lib/types";
-    import Modal from "./modal.svelte";
-    import { enhance } from "$app/forms";
-    import SafeMarkdown from "./safe_markdown.svelte";
+          import { formatRelative } from "date-fns";
+  import type { ClientsideComment, ClientsideUser } from "$lib/types";
+  import Modal from "./modal.svelte";
+  import { enhance } from "$app/forms";
+  import SafeMarkdown from "./safe_markdown.svelte";
+  import { updated } from "$app/state";
 
-    export let comment: ClientsideComment;
-    export let user: ClientsideUser | undefined = undefined;
-    export let isAdmin: boolean = false;
-    let isDeletionModalVisible: boolean = false;
+  export let comment: ClientsideComment;
+  export let user: ClientsideUser | undefined = undefined;
+  export let isAdmin: boolean = false;
+  export let onReply: ((comment: ClientsideComment) => void) = comment => {};
+  let isDeletionModalVisible: boolean = false;
 
-    $: commentDate = comment
-        ? formatRelative(new Date(comment.createdAt), new Date())
-        : "";
+  $: commentDate = comment
+    ? formatRelative(new Date(comment.createdAt), new Date())
+    : "";
 </script>
 
 <div class="comment">
-    <h3>
-        {#if comment.user && !comment.user.isTrusted}
-            <span style="color: red">(Pending review)</span> |{" "}
-        {/if}
-
-        <a href={`/user/${comment.user.id}`}>{comment.user.displayName}</a>
-        <span class="comment-date"> - {commentDate}</span>
-    </h3>
-    <SafeMarkdown source={comment.content} />
-    {#if isAdmin || (user && user.id === comment.user.id)}
-        <div id="comment-actions">
-            <button on:click={() => (isDeletionModalVisible = true)}
-                >Delete</button
-            >
-            <Modal bind:visible={isDeletionModalVisible}>
-                <h2>Delete this comment?</h2>
-                <p>Are you sure? This action cannot be undone.</p>
-                <p>Comment content:</p>
-                <pre>{comment.content}</pre>
-                <button on:click={() => (isDeletionModalVisible = false)}
-                    >Cancel</button
-                >
-                <form use:enhance action="?/delete_comment" method="post">
-                    <input type="hidden" name="id" value={comment.id} />
-                    <button type="submit">Confirm delete</button>
-                </form>
-            </Modal>
-        </div>
+  <h3>
+    {#if comment.user && !comment.user.isTrusted}
+      <span style="color: red">(Pending review)</span> |{" "}
     {/if}
+
+    <a href={`/user/${comment.user.id}`}>{comment.user.displayName}</a>
+    <span class="comment-date"> - {commentDate}</span>
+  </h3>
+  <SafeMarkdown source={comment.content} />
+
+  <div id="comment-actions">
+    {#if user}
+      <form method="post" action="?/reply_to_comment" use:enhance={() => {
+        return async ({ update }) => {
+            await update({ invalidateAll: false });
+            onReply(comment);
+        };
+      }}>
+        <input type="hidden" name="parentId" value={comment.id} />
+        <button type="submit">Reply</button>
+      </form>
+    {/if}
+
+    {#if isAdmin || (user && user.id === comment.user.id)}
+      <button on:click={() => (isDeletionModalVisible = true)}>Delete</button>
+      <Modal bind:visible={isDeletionModalVisible}>
+        <h2>Delete this comment?</h2>
+        <p>Are you sure? This action cannot be undone.</p>
+        <p>Comment content:</p>
+        <pre>{comment.content}</pre>
+        <button on:click={() => (isDeletionModalVisible = false)}>Cancel</button
+        >
+        <form use:enhance action="?/delete_comment" method="post">
+          <input type="hidden" name="id" value={comment.id} />
+          <button type="submit">Confirm delete</button>
+        </form>
+      </Modal>
+    {/if}
+  </div>
 </div>
 
 <style>
-    .comment {
-        margin-top: 1rem;
-        padding: 0.5rem;
-        background-color: #fff;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-    }
+  .comment {
+    margin-top: 1rem;
+    padding: 0.5rem;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
 
-    .comment h3 a {
-        color: #007bff;
-        text-decoration: none;
-    }
+  .comment h3 a {
+    color: #007bff;
+    text-decoration: none;
+  }
 
-    .comment .comment-date {
-        color: #6c757d; /* A muted color for the date */
-        font-size: 0.9em;
-        margin-left: 0.5em;
-    }
+  .comment .comment-date {
+    color: #6c757d; /* A muted color for the date */
+    font-size: 0.9em;
+    margin-left: 0.5em;
+  }
 
-    .comment pre {
-        white-space: pre-wrap;
-        background-color: #fff;
-        padding: 0.5rem;
-        border: none;
-        margin-top: 0.5rem;
-    }
+  .comment pre {
+    white-space: pre-wrap;
+    background-color: #fff;
+    padding: 0.5rem;
+    border: none;
+    margin-top: 0.5rem;
+  }
 
-    .comment #comment-actions {
-        margin-top: 0.5rem;
-    }
+  .comment #comment-actions {
+    margin-top: 0.5rem;
+    display: flex;
+    gap: 0.5rem;
+    align-items: center; /* So they're all at same height */
+    flex-wrap: wrap; /* allow wrapping on very small screens */
+  }
+
+  /* prevent direct child forms inside the actions area from adding extra vertical spacing
+     (this avoids changing layouts inside nested components like the Modal) */
+  .comment #comment-actions > form {
+    margin: 0;
+  }
 </style>

--- a/src/lib/components/comment.svelte
+++ b/src/lib/components/comment.svelte
@@ -29,6 +29,7 @@
   export let isAdmin: boolean = false;
   export let onReply: ((comment: ClientsideComment) => void) = comment => {};
   let isDeletionModalVisible: boolean = false;
+  let replyDisabled: boolean = false;
 
   $: commentDate = comment
     ? formatRelative(new Date(comment.createdAt), new Date())
@@ -49,13 +50,15 @@
   <div id="comment-actions">
     {#if user}
       <form method="post" action="?/reply_to_comment" use:enhance={() => {
+        replyDisabled = true;
         return async ({ update }) => {
             await update({ invalidateAll: false });
             onReply(comment);
+            replyDisabled = false;
         };
       }}>
         <input type="hidden" name="parentId" value={comment.id} />
-        <button type="submit">Reply</button>
+        <button type="submit" disabled={replyDisabled}>Reply</button>
       </form>
     {/if}
 

--- a/src/lib/components/comment_list.svelte
+++ b/src/lib/components/comment_list.svelte
@@ -23,13 +23,14 @@
   export let comments: ClientsideComment[];
   export let user: ClientsideUser | undefined = undefined;
   export let isAdmin: boolean = false;
+  export let onReply: ((comment: ClientsideComment) => void) = comment => {};
 </script>
 
 <section role="group" aria-label="Comments">
   <h2>Comments</h2>
   {#if comments.length > 0}
     {#each comments as comment (comment.id)}
-      <Comment {comment} {user} {isAdmin} />
+      <Comment {comment} {user} {isAdmin} {onReply} />
     {/each}
   {:else}
     <p>No comments yet</p>

--- a/src/lib/components/comment_list.svelte
+++ b/src/lib/components/comment_list.svelte
@@ -24,36 +24,23 @@
   export let user: ClientsideUser | undefined = undefined;
   export let isAdmin: boolean = false;
   export let onReply: ((comment: ClientsideComment) => void) = comment => {};
+  export let label: string = "comments";
 </script>
 
-<section role="group" aria-label="Comments">
-  <h2>Comments</h2>
-  {#if comments.length > 0}
+{#if comments.length > 0}
+<ul class="comments-list" aria-label={label}>
     {#each comments as comment (comment.id)}
-      <Comment {comment} {user} {isAdmin} {onReply} />
+      <li><Comment {comment} {user} {isAdmin} {onReply} /></li>
     {/each}
-  {:else}
-    <p>No comments yet</p>
-  {/if}
-</section>
+</ul>
+{/if}
+
 
 <style>
-  section[role="group"] {
-    margin-top: 1rem;
-    padding: 1rem;
-    background-color: #f9f9f9;
-    border: 1px solid #ccc;
-    border-radius: 8px;
-  }
+.comments-list {
+    list-style-type: none;
+    padding-left: 0;
+    margin-left: 0;
+}
 
-  section[role="group"] h2 {
-    color: #333;
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-  }
-
-  section[role="group"] p {
-    margin-top: 1rem;
-    color: #888;
-  }
 </style>

--- a/src/lib/server/database/migrations/20251115214821-make-comments-threaded.cjs
+++ b/src/lib/server/database/migrations/20251115214821-make-comments-threaded.cjs
@@ -1,0 +1,21 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn("Comments", "parentId", {
+      type: Sequelize.UUID,
+      allowNull: true,
+      // Comments with replies should be marked as tombstones instead of deleted, but this exists for when a user is banned
+      onDelete: "CASCADE",
+      references: {
+        model: "Comments",
+        key: "id",
+      },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn("Comments", "parentId");
+  },
+};

--- a/src/lib/server/database/models/comment.ts
+++ b/src/lib/server/database/models/comment.ts
@@ -1,6 +1,6 @@
 /*
  * This file is part of the audiopub project.
- * 
+ *
  * Copyright (C) 2024 the-byte-bender
  *
  * This program is free software: you can redistribute it and/or modify
@@ -35,8 +35,8 @@ import {
   HasMany,
 } from "sequelize-typescript";
 import Audio from "./audio";
-import User  from "./user";
-import type { ClientsideComment, ClientsideAudio} from "$lib/types";
+import User from "./user";
+import type { ClientsideComment, ClientsideAudio } from "$lib/types";
 
 @Table
 export default class Comment extends Model {
@@ -80,7 +80,11 @@ export default class Comment extends Model {
   @HasMany(() => Comment, { foreignKey: "parentId", as: "replies" })
   declare replies?: Comment[];
 
-  toClientside(includeAudio: boolean = false): ClientsideComment {
+  public countReplies!: () => Promise<number>;
+  toClientside(
+    includeAudio: boolean = false,
+    includeReplies: boolean = false
+  ): ClientsideComment {
     return {
       id: this.id,
       content: this.content,
@@ -88,6 +92,54 @@ export default class Comment extends Model {
       updatedAt: this.updatedAt.getTime(),
       user: this.user!.toClientside(),
       audio: includeAudio ? this.audio?.toClientside() : undefined,
+      replies: includeReplies
+        ? this.replies?.map((r) => r.toClientside(includeAudio, includeReplies))
+        : undefined,
     };
+  }
+
+  static constructThreads(flatList: Comment[]): Comment[] {
+    // Create an index for fast lookups of comments by ID
+    let index = new Map<string, Comment>();
+    // Populate the index
+    for (const comment of flatList) {
+      index.set(comment.id, comment);
+    }
+
+    // Now, build the tree structure
+    let roots: Comment[] = [];
+    for (const comment of flatList) {
+      if (!comment.parentId) {
+        // This is a root comment
+        roots.push(comment);
+        continue;
+      }
+
+      const parent = index.get(comment.parentId);
+      if (parent) {
+        if (!parent.replies) {
+          // Create a new replies array for this parent
+          parent.replies = [comment];
+        } else {
+          parent.replies.push(comment);
+        }
+      } else {
+        // Orphaned comment, no parent found
+        roots.push(comment);
+      }
+    }
+
+    // Recursively sort all comments by creation date
+    const recursiveSort = (comments: Comment[]) => {
+      comments.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+      for (const comment of comments) {
+        if (comment.replies) {
+          recursiveSort(comment.replies);
+        }
+      }
+    };
+    recursiveSort(roots);
+
+    return roots;
   }
 }

--- a/src/lib/server/database/models/comment.ts
+++ b/src/lib/server/database/models/comment.ts
@@ -32,6 +32,7 @@ import {
   BelongsTo,
   CreatedAt,
   UpdatedAt,
+  HasMany,
 } from "sequelize-typescript";
 import Audio from "./audio";
 import User  from "./user";
@@ -68,6 +69,16 @@ export default class Comment extends Model {
 
   @BelongsTo(() => Audio)
   declare audio?: Audio;
+
+  @ForeignKey(() => Comment)
+  @Column(DataType.UUID)
+  declare parentId?: string;
+
+  @BelongsTo(() => Comment, { foreignKey: "parentId", as: "parent" })
+  declare parent?: Comment;
+
+  @HasMany(() => Comment, { foreignKey: "parentId", as: "replies" })
+  declare replies?: Comment[];
 
   toClientside(includeAudio: boolean = false): ClientsideComment {
     return {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,6 +49,7 @@ export interface ClientsideComment {
     updatedAt: number;
     user: ClientsideUser;
     audio?: ClientsideAudio;
+    replies?: ClientsideComment[];
 }
 
 export enum NotificationType {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -135,7 +135,7 @@
             <a href="/register">Register</a>
         {/if}
     </nav>
-    <form use:enhance action="/search" method="get">
+    <form action="/search" method="get">
         <input type="text" name="q" placeholder="Search..." />
         <button type="submit">Search</button>
     </form>

--- a/src/routes/listen/[id]/+page.server.ts
+++ b/src/routes/listen/[id]/+page.server.ts
@@ -18,112 +18,197 @@
  */
 import fs from "fs/promises";
 import {
-    Audio,
-    Comment,
-    User,
-    AudioFollow,
-    Notification,
+  Audio,
+  Comment,
+  User,
+  AudioFollow,
+  Notification,
 } from "$lib/server/database";
 import AudioFavorite from "$lib/server/database/models/audio_favorite";
 import { error, fail, redirect } from "@sveltejs/kit";
 import type { Actions, PageServerLoad } from "./$types";
 import sendEmail from "$lib/server/email";
-import { Op, Sequelize } from "sequelize";
-
+import { json, Op, Sequelize } from "sequelize";
+import { Json } from "sequelize/lib/utils";
 
 export const load: PageServerLoad = async (event) => {
-    // Query 1: Get audio with user
+  // Query 1: Get audio with user
+  const audio = await Audio.findByPk(event.params.id, { include: User });
+  if (!audio) {
+    return error(404, "Not found");
+  }
+
+  const comments = await Comment.findAll({
+    where: { audioId: audio.id },
+    include: {
+      model: User,
+      where: event.locals.user?.isAdmin ? {} : { isTrusted: true },
+    },
+    // order: [["createdAt", "ASC"]],
+  });
+
+  if (event.locals.user) {
+    const relatedCommentIds = comments.map((c) => c.id);
+
+    const whereClause: any = {
+      userId: event.locals.user.id,
+      readAt: null,
+    };
+
+    const orConditions: any[] = [
+      {
+        targetType: "audio",
+        targetId: audio.id,
+      },
+    ];
+
+    if (relatedCommentIds.length > 0) {
+      orConditions.push({
+        targetType: "comment",
+        targetId: { [Op.in]: relatedCommentIds },
+      });
+    }
+
+    whereClause[Op.or] = orConditions;
+
+    await Notification.update({ readAt: new Date() }, { where: whereClause });
+  }
+
+  // Construct list of comment thread trees, for UI rendering
+  const sortedComments = Comment.constructThreads(comments);
+
+  // Query 2: Get interaction data (following status, favorite count, user favorite status)
+  let isFollowing = false;
+  let favoriteCount = 0;
+  let isFavorited = false;
+
+  try {
+    const results = await Promise.all([
+      // Check if user is following this audio
+      event.locals.user
+        ? AudioFollow.findOne({
+            where: { userId: event.locals.user.id, audioId: audio.id } as any,
+          })
+            .then((result) => !!result)
+            .catch((err) => {
+              console.error("Error checking follow status:", err);
+              return false;
+            })
+        : Promise.resolve(false),
+      // Get favorite count for this audio
+      AudioFavorite.count({
+        where: { audioId: audio.id },
+      }).catch((err) => {
+        console.error("Error getting favorite count:", err);
+        return 0;
+      }),
+      // Check if user has favorited this audio
+      event.locals.user
+        ? AudioFavorite.findOne({
+            where: { userId: event.locals.user.id, audioId: audio.id },
+          })
+            .then((result) => !!result)
+            .catch((err) => {
+              console.error("Error checking user favorite:", err);
+              return false;
+            })
+        : Promise.resolve(false),
+    ]);
+
+    isFollowing = results[0];
+    favoriteCount = results[1];
+    isFavorited = results[2];
+  } catch (err) {
+    console.error("Error fetching audio interaction data:", err);
+    // Continue with default values
+  }
+
+  return {
+    audio: audio.toClientside(true, favoriteCount, isFavorited),
+    comments: sortedComments.map((c) => c.toClientside(false, true)),
+    mimeType: audio.mimeType,
+    isFollowing,
+  };
+};
+
+export const actions: Actions = {
+  delete: async (event) => {
+    const user = event.locals.user;
     const audio = await Audio.findByPk(event.params.id, { include: User });
     if (!audio) {
-        return error(404, "Not found");
+      return error(404, "Not found");
+    }
+    if (!user || (!user.isAdmin && user.id !== audio.userId)) {
+      return error(403, "Forbidden");
+    }
+    await fs.unlink(audio.path);
+    await audio.destroy();
+    return redirect(303, "/");
+  },
+  add_comment: async (event) => {
+    const user = event.locals.user;
+    if (!user || !user.isVerified || user.isBanned) {
+      return error(403, "Forbidden");
     }
 
-    const comments = await Comment.findAll({
-        where: { audioId: audio.id },
-        include: {
-            model: User,
-            where: event.locals.user?.isAdmin ? {} : { isTrusted: true },
-        },
-        order: [["createdAt", "ASC"]],
+    const audio = await Audio.findByPk(event.params.id);
+    if (!audio) {
+      return error(404, "Not found");
+    }
+
+    const form = await event.request.formData();
+    const parentId = form.get("parentId") as string | null;
+    const comment = form.get("comment") as string;
+    if (!comment) {
+      return fail(400, { comment });
+    }
+    if (comment.length < 3 || comment.length > 4000) {
+      return fail(400, {
+        comment,
+        message: "Comment must be between 3 and 4000 characters",
+      });
+    }
+
+    const commentInDatabase = await Comment.create({
+      userId: user.id,
+      audioId: audio.id,
+      parentId,
+      content: comment,
     });
 
-    if (event.locals.user) {
-        const relatedCommentIds = comments.map((c) => c.id);
-
-        const whereClause: any = {
-            userId: event.locals.user.id,
-            readAt: null,
-        };
-
-        const orConditions: any[] = [
-            {
-                targetType: "audio",
-                targetId: audio.id,
-            },
-        ];
-
-        if (relatedCommentIds.length > 0) {
-            orConditions.push({
-                targetType: "comment",
-                targetId: { [Op.in]: relatedCommentIds },
-            });
-        }
-
-        whereClause[Op.or] = orConditions;
-
-        await Notification.update(
-            { readAt: new Date() },
-            { where: whereClause }
-        );
+    // Send notifications to followers
+    const followers = await AudioFollow.findAll({
+      where: { audioId: audio.id } as any,
+    });
+    const followerIds = new Set<string>(followers.map((f) => f.userId));
+    if (audio.userId) followerIds.add(audio.userId);
+    followerIds.delete(user.id);
+    const payloads = Array.from(followerIds).map((uid) => ({
+      userId: uid,
+      actorId: user.id,
+      type: "comment" as const,
+      targetType: "comment" as const,
+      targetId: commentInDatabase.id,
+      metadata: { audioId: audio.id },
+    }));
+    if (payloads.length) {
+      await Notification.bulkCreate(payloads as any);
     }
 
-    // Query 2: Get interaction data (following status, favorite count, user favorite status)
-    let isFollowing = false;
-    let favoriteCount = 0;
-    let isFavorited = false;
+    return { success: true };
+  },
+  reply_to_comment: async ({ request }) => {
+    const form = await request.formData();
+    const parentId = form.get("parentId") as string;
+    const parentComment = await Comment.findByPk(parentId, {
+      include: User,
+    });
 
-    try {
-        const results = await Promise.all([
-            // Check if user is following this audio
-            event.locals.user
-                ? AudioFollow.findOne({
-                      where: { userId: event.locals.user.id, audioId: audio.id } as any,
-                  }).then(result => !!result).catch(err => {
-                      console.error('Error checking follow status:', err);
-                      return false;
-                  })
-                : Promise.resolve(false),
-            // Get favorite count for this audio
-            AudioFavorite.count({
-                where: { audioId: audio.id }
-            }).catch(err => {
-                console.error('Error getting favorite count:', err);
-                return 0;
-            }),
-            // Check if user has favorited this audio
-            event.locals.user
-                ? AudioFavorite.findOne({
-                      where: { userId: event.locals.user.id, audioId: audio.id }
-                  }).then(result => !!result).catch(err => {
-                      console.error('Error checking user favorite:', err);
-                      return false;
-                  })
-                : Promise.resolve(false)
-        ]);
-
-        isFollowing = results[0];
-        favoriteCount = results[1];
-        isFavorited = results[2];
-    } catch (err) {
-        console.error('Error fetching audio interaction data:', err);
-        // Continue with default values
+    if (!parentComment) {
+      return error(404, "The comment you are replying to was not found");
     }
-
     return {
-        audio: audio.toClientside(true, favoriteCount, isFavorited),
-        comments: comments.map((c) => c.toClientside(false)),
-        mimeType: audio.mimeType,
-        isFollowing,
+      replyTo: parentComment.toClientside(false),
     };
 };
 
@@ -172,109 +257,57 @@ export const actions: Actions = {
             content: comment,
         });
 
-        // Send notifications to followers
-        const followers = await AudioFollow.findAll({
-            where: { audioId: audio.id } as any,
-        });
-        const followerIds = new Set<string>(followers.map((f) => f.userId));
-        if (audio.userId) followerIds.add(audio.userId);
-        followerIds.delete(user.id);
-        const payloads = Array.from(followerIds).map((uid) => ({
-            userId: uid,
-            actorId: user.id,
-            type: "comment" as const,
-            targetType: "comment" as const,
-            targetId: commentInDatabase.id,
-            metadata: { audioId: audio.id },
-        }));
-        if (payloads.length) {
-            await Notification.bulkCreate(payloads as any);
-        }
-        
-        return { success: true };
-    },
-    reply_to_comment: async ({ request }) => {
-        const form = await request.formData();
-        const parentId = form.get("parentId") as string;
-        const parentComment = await Comment.findByPk(parentId, {
-            include: User,
-        });
+    await comment.destroy();
+    return { success: true };
+  },
+  follow: async (event) => {
+    const user = event.locals.user;
+    if (!user || !user.isVerified || user.isBanned)
+      return error(403, "Forbidden");
+    const audio = await Audio.findByPk(event.params.id);
+    if (!audio) return error(404, "Not found");
+    if (audio.userId === user.id) return { success: true };
+    const existing = await AudioFollow.findOne({
+      where: { userId: user.id, audioId: audio.id } as any,
+    });
+    if (!existing) {
+      await AudioFollow.create({ userId: user.id, audioId: audio.id });
+    }
+    return { success: true };
+  },
+  unfollow: async (event) => {
+    const user = event.locals.user;
+    if (!user || !user.isVerified || user.isBanned)
+      return error(403, "Forbidden");
+    const audio = await Audio.findByPk(event.params.id);
+    if (!audio) return error(404, "Not found");
+    await AudioFollow.destroy({
+      where: { userId: user.id, audioId: audio.id } as any,
+    });
+    return { success: true };
+  },
+  favorite: async (event) => {
+    const user = event.locals.user;
+    if (!user || !user.isTrusted || user.isBanned)
+      return error(403, "Forbidden");
+    const audio = await Audio.findByPk(event.params.id);
+    if (!audio) return error(404, "Not found");
 
-        console.log(`Replying to comment ID: ${parentId}`, parentComment?.toJSON());
+    const favorite = await AudioFavorite.createFavorite(user.id, audio.id);
+    if (!favorite) {
+      // Already favorited, that's fine
+      return { success: true };
+    }
+    return { success: true };
+  },
+  unfavorite: async (event) => {
+    const user = event.locals.user;
+    if (!user || !user.isTrusted || user.isBanned)
+      return error(403, "Forbidden");
+    const audio = await Audio.findByPk(event.params.id);
+    if (!audio) return error(404, "Not found");
 
-        if (!parentComment) {
-            return error(404, "The comment you are replying to was not found");
-        }
-        return {
-            replyTo:    parentComment.toClientside(false),
-        };
-    },
-    delete_comment: async (event) => {
-        // Only an admin, or the user who made the comment can delete a comment
-        const user = event.locals.user;
-        const form = await event.request.formData();
-        const commentId = form.get("id") as string;
-        if (!commentId) {
-            return fail(400);
-        }
-        const comment = await Comment.findByPk(commentId, { include: User });
-        if (!comment) {
-            return error(404, "Not found");
-        }
-        if (!user || (!user.isAdmin && user.id !== comment.userId)) {
-            return error(403, "Forbidden");
-        }
-        await comment.destroy();
-        return { success: true };
-    },
-    follow: async (event) => {
-        const user = event.locals.user;
-        if (!user || !user.isVerified || user.isBanned)
-            return error(403, "Forbidden");
-        const audio = await Audio.findByPk(event.params.id);
-        if (!audio) return error(404, "Not found");
-        if (audio.userId === user.id) return { success: true };
-        const existing = await AudioFollow.findOne({
-            where: { userId: user.id, audioId: audio.id } as any,
-        });
-        if (!existing) {
-            await AudioFollow.create({ userId: user.id, audioId: audio.id });
-        }
-        return { success: true };
-    },
-    unfollow: async (event) => {
-        const user = event.locals.user;
-        if (!user || !user.isVerified || user.isBanned)
-            return error(403, "Forbidden");
-        const audio = await Audio.findByPk(event.params.id);
-        if (!audio) return error(404, "Not found");
-        await AudioFollow.destroy({
-            where: { userId: user.id, audioId: audio.id } as any,
-        });
-        return { success: true };
-    },
-    favorite: async (event) => {
-        const user = event.locals.user;
-        if (!user || !user.isTrusted || user.isBanned)
-            return error(403, "Forbidden");
-        const audio = await Audio.findByPk(event.params.id);
-        if (!audio) return error(404, "Not found");
-        
-        const favorite = await AudioFavorite.createFavorite(user.id, audio.id);
-        if (!favorite) {
-            // Already favorited, that's fine
-            return { success: true };
-        }
-        return { success: true };
-    },
-    unfavorite: async (event) => {
-        const user = event.locals.user;
-        if (!user || !user.isTrusted || user.isBanned)
-            return error(403, "Forbidden");
-        const audio = await Audio.findByPk(event.params.id);
-        if (!audio) return error(404, "Not found");
-        
-        await AudioFavorite.removeFavorite(user.id, audio.id);
-        return { success: true };
-    },
+    await AudioFavorite.removeFavorite(user.id, audio.id);
+    return { success: true };
+  },
 };

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -164,7 +164,7 @@ commentField.focus();
             <label for="comment">Add a comment:</label>
             {/if}
             <textarea bind:this={commentField} name="comment" id="comment" required maxlength="4000"></textarea>
-            <button type="submit">Submit</button>
+            <button type="submit">{form?.replyTo ? 'Reply' : 'Comment'}</button>
         </form>
     {/if}
 </div>

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -24,6 +24,10 @@
     import CommentList from "$lib/components/comment_list.svelte";
     import title from "$lib/title";
     import SafeMarkdown from "$lib/components/safe_markdown.svelte";
+  import type { ClientsideComment } from "$lib/types.js";
+
+export let form: any;
+
     onMount(() => title.set(data.audio.title));
     const handlePlay = () => {
         fetch(`/listen/${data.audio.id}/try_register_play`, { method: "POST" });
@@ -35,6 +39,11 @@
         if (count === 1) return "1 favorite";
         return `${count} favorites`;
     })();
+
+    let commentField: HTMLTextAreaElement;
+    function onReply(comment: ClientsideComment) {
+commentField.focus();
+    }
 </script>
 
 <h1>{data.audio.title}</h1>
@@ -136,6 +145,7 @@
         comments={data.comments}
         isAdmin={data.isAdmin}
         user={data.user}
+        {onReply}
     />
 
     {#if data.user && !data.user.isBanned}
@@ -147,9 +157,13 @@
             </p>
         {/if}
         <form use:enhance action="?/add_comment" method="POST">
+            {#if form?.replyTo}
+            <input type="hidden" name="parentId" value={form.replyTo.id} />
+            <label for="comment">Reply to @{form.replyTo.user.name}:</label>
+            {:else}
             <label for="comment">Add a comment:</label>
-            <textarea name="comment" id="comment" required maxlength="4000"
-            ></textarea>
+            {/if}
+            <textarea bind:this={commentField} name="comment" id="comment" required maxlength="4000"></textarea>
             <button type="submit">Submit</button>
         </form>
     {/if}

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -140,13 +140,19 @@ commentField.focus();
             <button type="submit"> Permanently delete</button>
         </form>
     {/if}
-
+<section role="group" aria-label="Comments">
+  <h2>Comments</h2>
+  {#if data.comments.length > 0}
     <CommentList
         comments={data.comments}
         isAdmin={data.isAdmin}
         user={data.user}
         {onReply}
     />
+    {:else}
+    <p>No comments yet</p>
+  {/if}
+</section>
 
     {#if data.user && !data.user.isBanned}
         {#if !data.user.isTrusted}
@@ -306,4 +312,23 @@ commentField.focus();
     .audio-details form button[type="submit"]:hover {
         background-color: #0056b3;
     }
+
+      section[role="group"] {
+    margin-top: 1rem;
+    padding: 1rem;
+    background-color: #f9f9f9;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+  }
+
+  section[role="group"] h2 {
+    color: #333;
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+    section[role="group"] p {
+    margin-top: 1rem;
+    color: #888;
+  }
 </style>


### PR DESCRIPTION
This PR implements comment replies, and thus threaded comments.

Depends on #9 to work to its full potential.
#### Todo
- [x] Add migration that adds parentId column to Comments table
- [x] Add Comment ->\* Comment associations in model
- [x] Allow retargetting comment field on listen pages, and posting comments with a non-null parentId
- [x] Progressively enhance reply retargetting, focus comment field on reply button press
- [x] Display comments in nested threads
- [x] Handle deleted comments with replies (should be tomb-stoned, and displayed with contents "Deleted", not removed entirely)
- [x] Handle comments from deleted users (likewise)
- [x] Discuss / design / implement a way to "untarget" the comment field, so you can send a toplevel comment after clicking "Reply".