### PR TITLE
Add audio chapters

### DIFF
--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -30,10 +30,96 @@
 
     export let form: any;
 
+    type Chapter = {
+        time: number;
+        label: string;
+        timestamp: string;
+    };
+
+    type ChapterSection = {
+        chapters: Chapter[];
+        description: string;
+    };
+
+    let audioElement: HTMLAudioElement | undefined;
+
     onMount(() => title.set(data.audio.title));
     const handlePlay = () => {
         fetch(`/listen/${data.audio.id}/try_register_play`, { method: "POST" });
     };
+
+    function parseTimestamp(timestamp: string): number | null {
+        const parts = timestamp.split(":").map(Number);
+        if (parts.some((part) => !Number.isInteger(part))) return null;
+        if (parts.length === 2) {
+            const [minutes, seconds] = parts;
+            if (seconds > 59) return null;
+            return minutes * 60 + seconds;
+        }
+        if (parts.length === 3) {
+            const [hours, minutes, seconds] = parts;
+            if (minutes > 59 || seconds > 59) return null;
+            return hours * 3600 + minutes * 60 + seconds;
+        }
+        return null;
+    }
+
+    function parseChapterLines(lines: string[]): Chapter[] {
+        return lines
+            .map((line) => {
+                const match = line.match(
+                    /^\s*(?:[-*+]\s*|\d+[.)]\s*)?\[?((?:\d{1,2}:)?\d{1,2}:\d{2})\]?\s*(?:[-:]\s*)?(.*)$/,
+                );
+                if (!match) return null;
+
+                const time = parseTimestamp(match[1]);
+                if (time === null) return null;
+
+                return {
+                    time,
+                    timestamp: match[1],
+                    label: match[2].trim() || "Chapter",
+                };
+            })
+            .filter((chapter): chapter is Chapter => chapter !== null)
+            .sort((a, b) => a.time - b.time);
+    }
+
+    function extractChapterSection(description: string): ChapterSection {
+        const lines = description.split("\n");
+        const start = lines.findIndex((line) =>
+            /^#{1,6}\s+chapters\s*$/i.test(line.trim()),
+        );
+        if (start === -1) {
+            return { chapters: [], description };
+        }
+
+        const end = lines.findIndex(
+            (line, index) =>
+                index > start && /^#{1,6}\s+\S/.test(line.trim()),
+        );
+        const chapterLines = lines.slice(start + 1, end === -1 ? undefined : end);
+        const renderedDescription = [
+            ...lines.slice(0, start),
+            ...(end === -1 ? [] : lines.slice(end)),
+        ]
+            .join("\n")
+            .trim();
+
+        return {
+            chapters: parseChapterLines(chapterLines),
+            description: renderedDescription,
+        };
+    }
+
+    function seekToChapter(time: number) {
+        if (!audioElement) return;
+        audioElement.currentTime = time;
+    }
+
+    $: chapterSection = extractChapterSection(data.audio.description || "");
+    $: chapters = chapterSection.chapters;
+    $: renderedDescription = chapterSection.description;
 
     $: favoritesString = (() => {
         const count = data.audio.favoriteCount || 0;
@@ -74,6 +160,7 @@
 <div class="audio-player">
     <AudioPlayer
         autofocus
+        bind:audioElement
         on:play={handlePlay}
         sources={[
             { src: `/${data.audio.path}`, type: data.mimeType },
@@ -146,6 +233,24 @@
         </p>
     {/if}
     <p>Upload date: {new Date(data.audio.createdAt).toLocaleDateString()}</p>
+    {#if chapters.length > 0}
+        <details class="chapters">
+            <summary>Chapters</summary>
+            <ol>
+                {#each chapters as chapter}
+                    <li>
+                        <button
+                            type="button"
+                            on:click={() => seekToChapter(chapter.time)}
+                        >
+                            <span>{chapter.timestamp}</span>
+                            {chapter.label}
+                        </button>
+                    </li>
+                {/each}
+            </ol>
+        </details>
+    {/if}
     {#if data.user}
         {#if data.audio.user && data.audio.user.id !== data.user.id}
             {#if data.isFollowing}
@@ -163,9 +268,9 @@
             {/if}
         {/if}
     {/if}
-    {#if data.audio.description}
+    {#if renderedDescription}
         <h2>Description:</h2>
-        <SafeMarkdown source={data.audio.description} />
+        <SafeMarkdown source={renderedDescription} />
     {/if}
 
     {#if data.user && (data.isAdmin || data.user.id === data.audio.user?.id)}
@@ -332,6 +437,46 @@
     .audio-details h2 {
         margin-top: 1rem;
         color: #333;
+    }
+
+    .chapters {
+        margin-top: 1rem;
+    }
+
+    .chapters summary {
+        cursor: pointer;
+        font-weight: 600;
+        color: #333;
+    }
+
+    .chapters ol {
+        margin: 0.5rem 0 0;
+        padding-left: 1.5rem;
+    }
+
+    .chapters li {
+        margin: 0.25rem 0;
+    }
+
+    .audio-details .chapters button {
+        background: none;
+        border: none;
+        color: #007bff;
+        cursor: pointer;
+        margin: 0;
+        padding: 0;
+        text-align: left;
+    }
+
+    .audio-details .chapters button:hover {
+        background: none;
+        text-decoration: underline;
+    }
+
+    .chapters span {
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+        margin-right: 0.5rem;
     }
 
     /* Styling for the delete and move buttons */

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -58,6 +58,13 @@
             maxlength="5000"
             class="form-control"
         ></textarea>
+        <p class="hint">
+            Add chapters with a <code>## Chapters</code> heading in the
+            description. Each line can use <code>- [00:00] Intro</code>,
+            <code>01:23 - Topic</code>, or <code>1:02:03 Outro</code>.
+            Chapters will appear as clickable timestamps on the audio page and
+            will be removed from the displayed description.
+        </p>
     </div>
     <div class="form-group">
         <label for="audio">Audio File:</label>
@@ -137,6 +144,12 @@
         color: #666;
         margin-bottom: 1rem;
         text-align: center;
+    }
+
+    .hint {
+        margin: 0.35rem 0 0;
+        font-size: 0.85rem;
+        color: #666;
     }
 
     .btn {


### PR DESCRIPTION
## Summary

- Parse a `## Chapters` section from audio descriptions.
- Show parsed chapters as clickable timestamps on the listen page.
- Hide the chapter section from the rendered description once it has been parsed.
- Expand the upload description hint with accepted chapter formats and behavior.

## Validation

- `npm run check` was run, but it fails because of existing diagnostics outside this change, mostly in `src/lib/components/quickfeed_player.svelte`.

## Notes

Chapter lines accept formats such as `- [00:00] Intro`, `01:23 - Topic`, and `1:02:03 Outro`.
