### PR TITLE
[codex] Use profile handles in user links

### DIFF
--- a/src/lib/components/audio_item.svelte
+++ b/src/lib/components/audio_item.svelte
@@ -41,7 +41,7 @@
     </h3>
     {#if audio.user}
         <p>
-            By <a href={`/user/${audio.user.id}`}>{audio.user.displayName}</a>
+            By <a href={`/user/@${encodeURIComponent(audio.user.name)}`}>{audio.user.displayName}</a>
         </p>
     {/if}
     <SafeMarkdown source={audio.description} />

--- a/src/lib/components/comment.svelte
+++ b/src/lib/components/comment.svelte
@@ -43,7 +43,7 @@
       <span style="color: red">(Pending review)</span> |{" "}
     {/if}
 
-    <a href={`/user/${comment.user.id}`}>{comment.user.displayName}</a>
+    <a href={`/user/@${encodeURIComponent(comment.user.name)}`}>{comment.user.displayName}</a>
     <span class="comment-date"> - {commentDate}</span>
   </h3>
   <SafeMarkdown source={comment.content} />

--- a/src/lib/components/notification.svelte
+++ b/src/lib/components/notification.svelte
@@ -60,7 +60,7 @@
     {#if notification.type === NotificationType.comment && notification.target}
         {@const comment = notification.target as ClientsideComment}
         <h3>
-            <a href={`/user/${notification.actor?.id}`}>
+            <a href={notification.actor ? `/user/@${encodeURIComponent(notification.actor.name)}` : undefined}>
                 {notification.actor?.displayName}
             </a>
             Commented on <a {href}>{comment.audio?.title}</a>
@@ -70,7 +70,7 @@
     {:else if notification.type === NotificationType.favorite && notification.target}
         {@const audio = notification.target}
         <h3>
-            <a href={`/user/${notification.actor?.id}`}>
+            <a href={notification.actor ? `/user/@${encodeURIComponent(notification.actor.name)}` : undefined}>
                 {notification.actor?.displayName}
             </a>
             favorited <a {href}>{(audio as any).title}</a>

--- a/src/lib/components/quickfeed_player.svelte
+++ b/src/lib/components/quickfeed_player.svelte
@@ -1657,7 +1657,7 @@
                         <h2>{audio.title}</h2>
                         {#if audio.user}
                             <p class="author">
-                                <a href="/user/{audio.user.id}">@{audio.user.displayName}</a>
+                                <a href="/user/@{encodeURIComponent(audio.user.name)}">@{audio.user.displayName}</a>
                             </p>
                         {/if}
                         <div class="description">

--- a/src/lib/components/stream_card.svelte
+++ b/src/lib/components/stream_card.svelte
@@ -40,7 +40,7 @@
     {#if stream.user}
         <p class="streamer">
             Streaming by
-            <a href="/user/{stream.user.id}">{stream.user.displayName}</a>
+            <a href="/user/@{encodeURIComponent(stream.user.name)}">{stream.user.displayName}</a>
         </p>
     {/if}
 

--- a/src/lib/components/stream_chat.svelte
+++ b/src/lib/components/stream_chat.svelte
@@ -39,7 +39,7 @@
 
 <article class="chat-message">
     <h3 class="chat-header">
-        <a href="/user/{chat.user.id}" class="username"
+        <a href="/user/@{encodeURIComponent(chat.user.name)}" class="username"
             >{chat.user.displayName}</a
         >
         <span class="chat-date">{chatDate}</span>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -46,7 +46,7 @@
             {#each data.untrustedUsers as u}
                 <tr>
                     <td>
-                        <a href="/user/{u.id}">{u.name}</a>
+                        <a href="/user/@{encodeURIComponent(u.name)}">{u.name}</a>
                     </td>
                     <td>{u.displayName}</td>
                     <td>{u.email}</td>

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -140,7 +140,7 @@
     </div>
     {#if data.audio.user}
         <p>
-            Uploaded by: <a href="/user/{data.audio.user.id}"
+            Uploaded by: <a href="/user/@{encodeURIComponent(data.audio.user.name)}"
                 >{data.audio.user.name}</a
             >
         </p>

--- a/src/routes/live/[id]/+page.svelte
+++ b/src/routes/live/[id]/+page.svelte
@@ -196,7 +196,7 @@
 
     {#if data.stream.user}
         <p>
-            Streaming by: <a href="/user/{data.stream.user.id}"
+            Streaming by: <a href="/user/@{encodeURIComponent(data.stream.user.name)}"
                 >{data.stream.user.displayName}</a
             >
         </p>

--- a/src/routes/user/[id]/+page.server.ts
+++ b/src/routes/user/[id]/+page.server.ts
@@ -21,12 +21,19 @@ import { error, redirect } from "@sveltejs/kit";
 import { Op } from "sequelize";
 import type { Actions, PageServerLoad } from "./$types";
 
+async function findUserByProfileParam(param: string) {
+    if (param.startsWith("@")) {
+        return User.findOne({ where: { name: param.slice(1).toLowerCase() } });
+    }
+    return User.findByPk(param);
+}
+
 export const load: PageServerLoad = async (event) => {
     const pageString = event.url.searchParams.get("page");
     const page = pageString ? parseInt(pageString, 10) : 1;
     const limit = 30;
     const offset = (page - 1) * limit;
-    const profileUser = await User.findByPk(event.params.id);
+    const profileUser = await findUserByProfileParam(event.params.id);
     if (!profileUser) {
         return redirect(303, "/");
     }
@@ -59,7 +66,7 @@ export const actions: Actions = {
         if (!user || !user.isAdmin) {
             return error(403, "Forbidden");
         }
-        const userToBeBanned = await User.findByPk(event.params.id);
+        const userToBeBanned = await findUserByProfileParam(event.params.id);
         if (!userToBeBanned) {
             return error(404, "User not found");
         }
@@ -72,14 +79,14 @@ export const actions: Actions = {
             await Audio.destroy({ where: { userId: userToBeBanned.id } });
             await Comment.destroy({ where: { userId: userToBeBanned.id } });
         }
-        return redirect(303, `/user/${userToBeBanned.id}`);
+        return redirect(303, `/user/@${encodeURIComponent(userToBeBanned.name)}`);
     },
     warn: async (event) => {
         const user = event.locals.user;
         if (!user || !user.isAdmin) {
             return error(403, "Forbidden");
         }
-        const userToBeWarned = await User.findByPk(event.params.id);
+        const userToBeWarned = await findUserByProfileParam(event.params.id);
         if (!userToBeWarned) {
             return error(404, "User not found");
         }
@@ -87,14 +94,14 @@ export const actions: Actions = {
         const reason = form.get("reason") as string;
         const message = form.get("message") as string;
         await userToBeWarned.warn(reason, message);
-        return redirect(303, `/user/${userToBeWarned.id}`);
+        return redirect(303, `/user/@${encodeURIComponent(userToBeWarned.name)}`);
     },
     trust: async (event) => {
         const user = event.locals.user;
         if (!user || !user.isAdmin) {
             return error(403, "Forbidden");
         }
-        const userToBeTrusted = await User.findByPk(event.params.id);
+        const userToBeTrusted = await findUserByProfileParam(event.params.id);
         if (!userToBeTrusted) {
             return error(404, "User not found");
         }

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -25,9 +25,31 @@
     import { onMount } from "svelte";
     export let data;
     onMount(() => title.set(`${data.profileUser.displayName}'s Profile`));
+
+    function onShareClick() {
+        const url = `${window.location.origin}/user/@${encodeURIComponent(data.profileUser.name)}`;
+        if (navigator.share) {
+            navigator
+                .share({
+                    title: `${data.profileUser.displayName}'s Profile`,
+                    url,
+                })
+                .catch((error) => console.log("Error sharing", error));
+        } else {
+            navigator.clipboard
+                .writeText(url)
+                .then(() => {
+                    alert("Link copied to clipboard");
+                })
+                .catch((err) => {
+                    console.error("Could not copy text: ", err);
+                });
+        }
+    }
 </script>
 
 <h1>{data.profileUser.displayName}'s Profile</h1>
+<button on:click={onShareClick}>Share profile</button>
 
 <table>
     <tbody>
@@ -95,7 +117,7 @@
     groupThreshold={0}
     page={data.page}
     totalPages={data.totalPages}
-    paginationBaseUrl={`/user/${data.profileUser.id}`}
+    paginationBaseUrl={`/user/@${encodeURIComponent(data.profileUser.name)}`}
 />
 
 <style>


### PR DESCRIPTION
## Summary

- Route public profile pages through `/user/@username` while still accepting existing UUID profile URLs.
- Update generated profile links across audio, comment, stream, notification, admin, and quickfeed views.
- Add a `Share profile` button that shares the canonical handle URL or copies it to the clipboard.

## Impact

Profile links are now easier to read and share without changing authentication, authorization, or admin permission checks. Existing UUID-based profile URLs continue to resolve through the compatibility lookup.

## Validation

- Ran `npm run check`; it still fails because of pre-existing TypeScript errors in `quickfeed_player.svelte` and `listen/[id]/+page.svelte`, unrelated to this change.
- Ran a focused `svelte-check` filter for the touched profile route and related components; no new diagnostics were reported for the profile route.
