### PR TITLE
Preserve browser navigation shortcuts in audio players

### DIFF
--- a/src/lib/components/audio_player.svelte
+++ b/src/lib/components/audio_player.svelte
@@ -81,6 +81,8 @@
     }
 
     function onKeydown(event: KeyboardEvent) {
+        if (event.altKey || event.ctrlKey || event.metaKey) return;
+
         // Don't hijack keys while focus is on the sliders themselves.
         const target = event.target as HTMLElement;
         if (target?.tagName === "INPUT") return;

--- a/src/lib/components/quickfeed_player.svelte
+++ b/src/lib/components/quickfeed_player.svelte
@@ -1221,6 +1221,10 @@
             console.log('⏭️ Skipping shortcuts - modal open or input focused');
             return;
         }
+
+        if (event.altKey || event.ctrlKey || event.metaKey) {
+            return;
+        }
         
         switch (event.key) {
             case 'ArrowUp':


### PR DESCRIPTION
## Summary
- Ignore modified keyboard shortcuts in audio player handlers so browser navigation shortcuts remain available.
- Prevent Alt/Ctrl/Meta + arrow keys from being treated as seek commands in the standard and quickfeed players.

## Validation
- npm run check currently fails due to existing unrelated TypeScript/Svelte diagnostics in quickfeed_player.svelte, listen/[id], and other files.