### PR TITLE
Fix subscription bugs

### DIFF
--- a/src/routes/subscriptions/+page.server.ts
+++ b/src/routes/subscriptions/+page.server.ts
@@ -33,7 +33,7 @@ export const load: ServerLoad = async (event) => {
             page === 1
                 ? (
                       await Stream.findAll({
-                          where: { state: "active" } ,
+                          where: { state: "active", userId: { [Op.in]: subscribedToUsers } } ,
                           order: [["createdAt", "DESC"]],
                           include: User,
                       })

--- a/src/routes/subscriptions/+page.svelte
+++ b/src/routes/subscriptions/+page.svelte
@@ -25,6 +25,7 @@
     totalPages={data.totalPages}
     currentUser={data.user}
     paginationBaseUrl="/subscriptions"
+    groupThreshold={0}
 />
 {:else if data.streams.length == 0}
 Nobody you subscribed to has posted yet

--- a/src/routes/upload/+page.server.ts
+++ b/src/routes/upload/+page.server.ts
@@ -95,7 +95,7 @@ export const actions: Actions = {
                 userId: subscription.subscriberId,
                 actorId: user.id,
                 type: NotificationType.upload,
-                targetType: NotificationTargetType.stream,
+                targetType: NotificationTargetType.audio,
                 targetId: audio.id,
             });
         }


### PR DESCRIPTION
This fixes a few minor but very important bugs with subscriptions:
- The upload notification had its target type set to stream so it would say that the person went live instead of uploaded
- There was no filter for subscribed to users for streams on the subscriptions page so it would show all streams instead of only by the people the user has subscribed to
- Group threshold was left on default on the subscriptions page so the list would collapse consecutive uploads from the same user which I didn't intend for that page

I'm sorry for not catching these earlier before the original pull request was merged.