### PR TITLE
Fix favorite counts not showing on pages

### DIFF
--- a/src/routes/profile/+page.server.ts
+++ b/src/routes/profile/+page.server.ts
@@ -18,7 +18,7 @@
  */
 import { fail, redirect, type Actions } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
-import { User, Audio } from "$lib/server/database";
+import { User, Audio, AudioFavorite } from "$lib/server/database";
 import { hash } from "bcrypt";
 import { v4 as uuidv4 } from "uuid";
 
@@ -40,13 +40,19 @@ export const load: PageServerLoad = async (event) => {
         order: [["createdAt", "DESC"]],
     });
 
+    let clientsideAudios = [];
+    for (const audio of audios.rows) {
+        const favoriteCount = await AudioFavorite.count({ where: { audioId: audio.id } });
+        clientsideAudios.push(audio.toClientside(true, favoriteCount));
+    }
+
     return {
         name: user.name,
         email: user.email,
         displayName: user.displayName,
         bio: user.bio,
         streamKey: user.streamKey,
-        audios: audios.rows.map((audio) => audio.toClientside()),
+        audios: clientsideAudios,
         count: audios.count,
         page,
         limit,

--- a/src/routes/subscriptions/+page.server.ts
+++ b/src/routes/subscriptions/+page.server.ts
@@ -1,4 +1,4 @@
-import { Audio, Stream, User } from "$lib/server/database";
+import { Audio, AudioFavorite, Stream, User } from "$lib/server/database";
 import Subscription from "$lib/server/database/models/subscription";
 import { redirect, type ServerLoad } from "@sveltejs/kit";
 import { Op } from "sequelize";
@@ -26,7 +26,13 @@ export const load: ServerLoad = async (event) => {
         offset,
         order: [["createdAt", "DESC"]],
         include: User
-    });    
+    });
+
+    let clientsideAudios = [];
+    for (const audio of audios.rows) {
+        const favoriteCount = await AudioFavorite.count({ where: { audioId: audio.id } });
+        clientsideAudios.push(audio.toClientside(true, favoriteCount));
+    }
 
     return {
         streams:
@@ -39,7 +45,7 @@ export const load: ServerLoad = async (event) => {
                       })
                   ).map((s) => s.toClientside(true))
                 : [],
-        audios: audios.rows.map((audio) => audio.toClientside()),
+        audios: clientsideAudios,
         count: audios.count,
         page,
         limit,

--- a/src/routes/user/[id]/+page.server.ts
+++ b/src/routes/user/[id]/+page.server.ts
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
-import { Audio, Comment, User, Stream } from "$lib/server/database";
+import { Audio, Comment, User, Stream, AudioFavorite } from "$lib/server/database";
 import { error, redirect } from "@sveltejs/kit";
 import { Op } from "sequelize";
 import type { Actions, PageServerLoad } from "./$types";
@@ -64,6 +64,12 @@ export const load: PageServerLoad = async (event) => {
         }),
     ]);
 
+    let clientsideAudios = [];
+    for (const audio of audios.rows) {
+        const favoriteCount = await AudioFavorite.count({ where: { audioId: audio.id } });
+        clientsideAudios.push(audio.toClientside(true, favoriteCount));
+    }
+
     const subscribers = await Subscription.count({
         where: { subscribedToId: profileUser.id }
     });
@@ -82,7 +88,7 @@ export const load: PageServerLoad = async (event) => {
 
     return {
         stream: activeStream?.toClientside(false) ?? null,
-        audios: audios.rows.map((audio) => audio.toClientside()),
+        audios: clientsideAudios,
         count: audios.count,
         page,
         limit,


### PR DESCRIPTION
This fixes the bug where the favorite count would always be 0 on any page except the homepage. This was due to the favorite count never being fetched server side on those pages.