### PR TITLE
Add audio detail editing and moderation history

### DIFF
--- a/src/lib/server/audio_edits.ts
+++ b/src/lib/server/audio_edits.ts
@@ -1,0 +1,58 @@
+import { Audio, AudioEdit, User } from "$lib/server/database";
+import database from "$lib/server/database";
+
+export const MAX_USER_AUDIO_EDITS = 3;
+
+export class AudioEditLimitError extends Error {}
+export class AudioNotFoundError extends Error {}
+
+export async function updateAudioDetails(
+    audioId: string,
+    editor: User,
+    title: string,
+    description: string,
+    restoredEditId: string | null = null,
+): Promise<AudioEdit | null> {
+    return database.transaction(async (transaction) => {
+        const audio = await Audio.findByPk(audioId, {
+            transaction,
+            lock: transaction.LOCK.UPDATE,
+        });
+        if (!audio) {
+            throw new AudioNotFoundError();
+        }
+
+        if (audio.title === title && audio.description === description) {
+            return null;
+        }
+
+        if (!editor.isAdmin) {
+            const editCount = await AudioEdit.count({
+                where: { audioId, isAdminEdit: false },
+                transaction,
+            });
+            if (editCount >= MAX_USER_AUDIO_EDITS) {
+                throw new AudioEditLimitError();
+            }
+        }
+
+        const edit = await AudioEdit.create(
+            {
+                audioId,
+                editorId: editor.id,
+                previousTitle: audio.title,
+                previousDescription: audio.description,
+                newTitle: title,
+                newDescription: description,
+                isAdminEdit: editor.isAdmin,
+                restoredEditId,
+            },
+            { transaction },
+        );
+
+        audio.title = title;
+        audio.description = description;
+        await audio.save({ transaction });
+        return edit;
+    });
+}

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -29,6 +29,7 @@ import Stream from "./models/stream";
 import StreamChat from "./models/stream_chat";
 import StreamMute from "./models/stream_mute";
 import Subscription from "./models/subscription"
+import AudioEdit from "./models/audio_edit";
 dotenv.config();
 
 if (
@@ -46,7 +47,7 @@ const database = new Sequelize({
     dialect: "mariadb",
     username: process.env.DATABASE_USER,
     password: process.env.DATABASE_PASSWORD,
-    models: [User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription],
+    models: [User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit],
     logging: false,
     host: "127.0.0.1",
     port: 3306,
@@ -54,4 +55,4 @@ const database = new Sequelize({
 
 export default database;
 
-export { User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription };
+export { User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit };

--- a/src/lib/server/database/migrations/20260806000001-add-audio-edits.cjs
+++ b/src/lib/server/database/migrations/20260806000001-add-audio-edits.cjs
@@ -1,0 +1,72 @@
+"use strict";
+
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable("AudioEdits", {
+            id: {
+                allowNull: false,
+                primaryKey: true,
+                type: Sequelize.UUID,
+                defaultValue: Sequelize.UUIDV4,
+            },
+            audioId: {
+                allowNull: false,
+                type: Sequelize.UUID,
+                references: { model: "Audios", key: "id" },
+                onDelete: "CASCADE",
+                onUpdate: "CASCADE",
+            },
+            editorId: {
+                allowNull: true,
+                type: Sequelize.UUID,
+                references: { model: "Users", key: "id" },
+                onDelete: "SET NULL",
+                onUpdate: "CASCADE",
+            },
+            previousTitle: {
+                allowNull: false,
+                type: Sequelize.TEXT,
+            },
+            previousDescription: {
+                allowNull: false,
+                type: Sequelize.TEXT,
+            },
+            newTitle: {
+                allowNull: false,
+                type: Sequelize.TEXT,
+            },
+            newDescription: {
+                allowNull: false,
+                type: Sequelize.TEXT,
+            },
+            isAdminEdit: {
+                allowNull: false,
+                type: Sequelize.BOOLEAN,
+                defaultValue: false,
+            },
+            restoredEditId: {
+                allowNull: true,
+                type: Sequelize.UUID,
+                references: { model: "AudioEdits", key: "id" },
+                onDelete: "SET NULL",
+                onUpdate: "CASCADE",
+            },
+            createdAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+            updatedAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+        });
+
+        await queryInterface.addIndex("AudioEdits", ["audioId", "createdAt"]);
+        await queryInterface.addIndex("AudioEdits", ["createdAt"]);
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable("AudioEdits");
+    },
+};

--- a/src/lib/server/database/models/audio_edit.ts
+++ b/src/lib/server/database/models/audio_edit.ts
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2026 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+import {
+    AllowNull,
+    BelongsTo,
+    Column,
+    DataType,
+    Default,
+    ForeignKey,
+    Model,
+    PrimaryKey,
+    Table,
+} from "sequelize-typescript";
+import Audio from "./audio";
+import User from "./user";
+
+@Table
+export default class AudioEdit extends Model {
+    @PrimaryKey
+    @AllowNull(false)
+    @Default(DataType.UUIDV4)
+    @Column(DataType.UUID)
+    declare id: string;
+
+    @ForeignKey(() => Audio)
+    @AllowNull(false)
+    @Column(DataType.UUID)
+    declare audioId: string;
+
+    @BelongsTo(() => Audio)
+    declare audio?: Audio;
+
+    @ForeignKey(() => User)
+    @AllowNull(true)
+    @Column(DataType.UUID)
+    declare editorId: string | null;
+
+    @BelongsTo(() => User)
+    declare editor?: User;
+
+    @AllowNull(false)
+    @Column(DataType.TEXT)
+    declare previousTitle: string;
+
+    @AllowNull(false)
+    @Column(DataType.TEXT)
+    declare previousDescription: string;
+
+    @AllowNull(false)
+    @Column(DataType.TEXT)
+    declare newTitle: string;
+
+    @AllowNull(false)
+    @Column(DataType.TEXT)
+    declare newDescription: string;
+
+    @AllowNull(false)
+    @Default(false)
+    @Column(DataType.BOOLEAN)
+    declare isAdminEdit: boolean;
+
+    @AllowNull(true)
+    @Column(DataType.UUID)
+    declare restoredEditId: string | null;
+}

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -16,7 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
-import { User } from "$lib/server/database";
+import { Audio, AudioEdit, User } from "$lib/server/database";
+import { updateAudioDetails } from "$lib/server/audio_edits";
 import { error, redirect } from "@sveltejs/kit";
 import type { Actions, PageServerLoad } from "./$types";
 
@@ -30,6 +31,18 @@ export const load: PageServerLoad = async (event) => {
         where: { isTrusted: false, isBanned: false, verificationToken: null },
         order: [["createdAt", "DESC"]],
     });
+    const recentEdits = await AudioEdit.findAll({
+        include: [
+            {
+                model: Audio,
+                as: "audio",
+                include: [{ model: User }],
+            },
+            { model: User, as: "editor" },
+        ],
+        order: [["createdAt", "DESC"]],
+        limit: 50,
+    });
 
     return {
         untrustedUsers: untrustedUsers.map((u) => ({
@@ -40,10 +53,49 @@ export const load: PageServerLoad = async (event) => {
             bio: u.bio,
             createdAt: u.createdAt.toISOString(),
         })),
+        recentEdits: recentEdits.map((edit) => ({
+            id: edit.id,
+            audioId: edit.audioId,
+            audioTitle: edit.audio?.title,
+            audioOwner: edit.audio?.user?.name,
+            editor: edit.editor?.name,
+            previousTitle: edit.previousTitle,
+            previousDescription: edit.previousDescription,
+            newTitle: edit.newTitle,
+            newDescription: edit.newDescription,
+            isAdminEdit: edit.isAdminEdit,
+            restoredEditId: edit.restoredEditId,
+            createdAt: edit.createdAt.toISOString(),
+        })),
     };
 };
 
 export const actions: Actions = {
+    restoreEdit: async (event) => {
+        const user = event.locals.user;
+        if (!user || !user.isAdmin) {
+            return error(403, "Forbidden");
+        }
+        const form = await event.request.formData();
+        const editId = form.get("editId");
+        if (typeof editId !== "string" || !editId) {
+            return error(400, "Missing edit id");
+        }
+
+        const edit = await AudioEdit.findByPk(editId, { include: [Audio] });
+        if (!edit || !edit.audio) {
+            return error(404, "Edit not found");
+        }
+
+        await updateAudioDetails(
+            edit.audioId,
+            user,
+            edit.previousTitle,
+            edit.previousDescription,
+            edit.id,
+        );
+        return { restoreSuccess: true };
+    },
     trust: async (event) => {
         const user = event.locals.user;
         if (!user || !user.isAdmin) {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -20,8 +20,16 @@
     import { enhance } from "$app/forms";
     import title from "$lib/title.js";
     import { onMount } from "svelte";
+    import Modal from "$lib/components/modal.svelte";
 
     export let data;
+    let selectedEdit: any = null;
+    let showEditDialog = false;
+
+    function openEditDialog(edit: any) {
+        selectedEdit = edit;
+        showEditDialog = true;
+    }
 
     onMount(() => title.set("Admin"));
 </script>
@@ -64,6 +72,69 @@
     </table>
 {/if}
 
+<h1>Recent Audio Edits</h1>
+
+{#if data.recentEdits.length === 0}
+    <p>No audio edits.</p>
+{:else}
+    <div class="edit-list">
+        {#each data.recentEdits as edit}
+            <article>
+                <h2>
+                    <a href="/listen/{edit.audioId}">{edit.audioTitle}</a>
+                    <span class="edited-tag">[edited]</span>
+                </h2>
+                <p>
+                    Edited by @{edit.editor || "unknown"} on
+                    {new Date(edit.createdAt).toLocaleString()}.
+                    {#if edit.audioOwner}Owner: @{edit.audioOwner}.{/if}
+                    {#if edit.isAdminEdit}Administrator edit.{/if}
+                    {#if edit.restoredEditId}Restoration of an earlier edit.{/if}
+                </p>
+                <button type="button" on:click={() => openEditDialog(edit)}
+                    >View details</button
+                >
+            </article>
+        {/each}
+    </div>
+{/if}
+
+<Modal bind:visible={showEditDialog}>
+    {#if selectedEdit}
+        <div class="edit-dialog-content">
+            <h2>Edit details</h2>
+            <p>
+                <a href="/listen/{selectedEdit.audioId}">{selectedEdit.audioTitle}</a>
+                edited by @{selectedEdit.editor || "unknown"} on
+                {new Date(selectedEdit.createdAt).toLocaleString()}.
+            </p>
+            <p><strong>Title:</strong> {selectedEdit.previousTitle} → {selectedEdit.newTitle}</p>
+            <p><strong>Previous description:</strong></p>
+            <pre>{selectedEdit.previousDescription}</pre>
+            <p><strong>New description:</strong></p>
+            <pre>{selectedEdit.newDescription}</pre>
+            <form
+                use:enhance={() => {
+                    return async ({ result, update }) => {
+                        await update();
+                        if (result.type === "success") {
+                            showEditDialog = false;
+                        }
+                    };
+                }}
+                action="?/restoreEdit"
+                method="post"
+            >
+                <input type="hidden" name="editId" value={selectedEdit.id} />
+                <button type="submit">Revert this edit</button>
+            </form>
+            <button type="button" on:click={() => (showEditDialog = false)}
+                >Close</button
+            >
+        </div>
+    {/if}
+</Modal>
+
 <style>
     table {
         width: 100%;
@@ -98,5 +169,30 @@
 
     button:hover {
         background-color: #444;
+    }
+
+    .edit-list {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .edit-list article {
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        padding: 1rem;
+    }
+
+    .edit-list h2 {
+        margin-top: 0;
+    }
+
+    .edit-dialog-content pre {
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+    }
+
+    .edited-tag {
+        font-size: 0.65em;
+        font-weight: normal;
     }
 </style>

--- a/src/routes/listen/[id]/+page.server.ts
+++ b/src/routes/listen/[id]/+page.server.ts
@@ -26,6 +26,7 @@ import {
     Stream,
     StreamChat,
     Subscription,
+    AudioEdit,
 } from "$lib/server/database";
 import AudioFavorite from "$lib/server/database/models/audio_favorite";
 import { error, fail, redirect } from "@sveltejs/kit";
@@ -34,6 +35,12 @@ import sendEmail from "$lib/server/email";
 import { json, Op, Sequelize } from "sequelize";
 import { Json } from "sequelize/lib/utils";
 import { subscribe, unsubscribe } from "$lib/server/subscriptions";
+import {
+    AudioEditLimitError,
+    AudioNotFoundError,
+    MAX_USER_AUDIO_EDITS,
+    updateAudioDetails,
+} from "$lib/server/audio_edits";
 
 export const load: PageServerLoad = async (event) => {
     const audio = await Audio.findByPk(event.params.id, {
@@ -97,6 +104,17 @@ export const load: PageServerLoad = async (event) => {
     }
 
     const sortedComments = Comment.constructThreads(comments);
+    const canEdit = Boolean(
+        viewer && (viewer.isAdmin || viewer.id === audio.userId),
+    );
+    const edits = canEdit
+        ? await AudioEdit.findAll({
+              where: { audioId: audio.id },
+              include: [{ model: User, as: "editor" }],
+              order: [["createdAt", "DESC"]],
+          })
+        : [];
+    const userEditCount = edits.filter((edit) => !edit.isAdminEdit).length;
 
     // Query 2: Get interaction data (following status, favorite count, user favorite status)
     let isFollowing = false;
@@ -149,15 +167,15 @@ export const load: PageServerLoad = async (event) => {
         // Continue with default values
     }
 
-            const subscribers = await Subscription.count({
-            where: { subscribedToId: audio.userId }
-        });
+    const subscribers = await Subscription.count({
+        where: { subscribedToId: audio.userId },
+    });
     
     const user = event.locals.user;
     let subscription;
     if (user) {
         subscription = await Subscription.findOne({
-            where: { subscriberId: user.id, subscribedToId: audio.userId }
+            where: { subscriberId: user.id, subscribedToId: audio.userId },
         });
     }
         
@@ -178,11 +196,107 @@ export const load: PageServerLoad = async (event) => {
                   order: [["createdAt", "ASC"]],
               }).then((chats) => chats.map((c) => c.toClientside()))
             : null,
-            isSubscribed
+        isSubscribed,
+        canEdit,
+        hasEdits: Boolean(viewer?.isAdmin && edits.length > 0),
+        remainingEdits: viewer?.isAdmin
+            ? null
+            : Math.max(0, MAX_USER_AUDIO_EDITS - userEditCount),
+        edits: edits.map((edit) => ({
+            id: edit.id,
+            previousTitle: edit.previousTitle,
+            previousDescription: edit.previousDescription,
+            newTitle: edit.newTitle,
+            newDescription: edit.newDescription,
+            isAdminEdit: edit.isAdminEdit,
+            restoredEditId: edit.restoredEditId,
+            createdAt: edit.createdAt.toISOString(),
+            editor: edit.editor?.toClientside(),
+        })),
     };
 };
 
 export const actions: Actions = {
+    revertEdit: async (event) => {
+        const user = event.locals.user;
+        if (!user || !user.isAdmin) {
+            return error(403, "Forbidden");
+        }
+        const form = await event.request.formData();
+        const editId = form.get("editId");
+        if (typeof editId !== "string" || !editId) {
+            return error(400, "Missing edit id");
+        }
+
+        const edit = await AudioEdit.findByPk(editId);
+        if (!edit || edit.audioId !== event.params.id) {
+            return error(404, "Edit not found");
+        }
+
+        await updateAudioDetails(
+            edit.audioId,
+            user,
+            edit.previousTitle,
+            edit.previousDescription,
+            edit.id,
+        );
+        return { revertSuccess: true };
+    },
+    edit: async (event) => {
+        const user = event.locals.user;
+        const audio = await Audio.findByPk(event.params.id);
+        if (!audio) {
+            return error(404, "Not found");
+        }
+        if (!user || (!user.isAdmin && user.id !== audio.userId)) {
+            return error(403, "Forbidden");
+        }
+        if (!user.isAdmin && (user.isBanned || !user.isVerified)) {
+            return error(403, "Forbidden");
+        }
+
+        const form = await event.request.formData();
+        const titleValue = form.get("title");
+        const descriptionValue = form.get("description");
+        const title = typeof titleValue === "string" ? titleValue.trim() : "";
+        const description =
+            typeof descriptionValue === "string" ? descriptionValue : "";
+
+        if (title.length < 3 || title.length > 120) {
+            return fail(400, {
+                editMessage: "Title must be between 3 and 120 characters",
+            });
+        }
+        if (description.length > 5000) {
+            return fail(400, {
+                editMessage: "Description must not exceed 5000 characters",
+            });
+        }
+
+        try {
+            const edit = await updateAudioDetails(
+                audio.id,
+                user,
+                title,
+                description,
+            );
+            if (!edit) {
+                return fail(400, { editMessage: "No changes were made" });
+            }
+        } catch (err) {
+            if (err instanceof AudioEditLimitError) {
+                return fail(403, {
+                    editMessage: "You have reached the limit of 3 edits",
+                });
+            }
+            if (err instanceof AudioNotFoundError) {
+                return error(404, "Not found");
+            }
+            throw err;
+        }
+
+        return { editSuccess: true };
+    },
     delete: async (event) => {
         const user = event.locals.user;
         const audio = await Audio.findByPk(event.params.id, { include: User });

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -28,6 +28,7 @@
     import type { ClientsideComment } from "$lib/types.js";
     import SubscribeButton from "$lib/components/subscribe_button.svelte";
     import AudioPlayer from "$lib/components/audio_player.svelte";
+    import Modal from "$lib/components/modal.svelte";
 
     export let form: any;
 
@@ -43,6 +44,8 @@
     };
 
     let audioElement: HTMLAudioElement | undefined;
+    let showEditDialog = false;
+    let showHistoryDialog = false;
 
     onMount(() => title.set(data.audio.title));
     const handlePlay = () => {
@@ -156,7 +159,10 @@
     }
 </script>
 
-<h1>{data.audio.title}</h1>
+<h1>
+    {data.audio.title}
+    {#if data.hasEdits}<span class="edited-tag">[edited]</span>{/if}
+</h1>
 
 <div class="audio-player">
     <AudioPlayer
@@ -275,6 +281,114 @@
     {#if renderedDescription}
         <h2>Description:</h2>
         <SafeMarkdown source={renderedDescription} />
+    {/if}
+
+    {#if data.canEdit}
+        <button
+            type="button"
+            on:click={() => (showEditDialog = true)}
+            disabled={data.remainingEdits === 0}>Edit audio details</button
+        >
+        {#if data.remainingEdits === 0}
+            <p>You have used all 3 available edits.</p>
+        {/if}
+
+        <Modal bind:visible={showEditDialog}>
+            <h2>Edit audio details</h2>
+            {#if form?.editMessage}
+                <p class="form-message" role="alert">{form.editMessage}</p>
+            {/if}
+            <form
+                class="edit-form"
+                use:enhance={() => {
+                    return async ({ result, update }) => {
+                        await update();
+                        if (result.type === "success") {
+                            showEditDialog = false;
+                        }
+                    };
+                }}
+                action="?/edit"
+                method="POST"
+            >
+                    <label for="edit-title">Title:</label>
+                    <input
+                        id="edit-title"
+                        name="title"
+                        type="text"
+                        value={data.audio.title}
+                        required
+                        minlength="3"
+                        maxlength="120"
+                    />
+                    <label for="edit-description">Description:</label>
+                    <textarea
+                        id="edit-description"
+                        name="description"
+                        maxlength="5000"
+                        value={data.audio.description}
+                    ></textarea>
+                    {#if data.remainingEdits !== null}
+                        <p>{data.remainingEdits} edit(s) remaining.</p>
+                    {/if}
+                    <button type="submit">Save changes</button>
+                    <button
+                        type="button"
+                        on:click={() => (showEditDialog = false)}>Cancel</button
+                    >
+            </form>
+        </Modal>
+
+        {#if data.edits.length > 0}
+            <button type="button" on:click={() => (showHistoryDialog = true)}
+                >View edit history</button
+            >
+            <Modal bind:visible={showHistoryDialog}>
+                <h2>Edit history</h2>
+                <ol class="edit-history">
+                    {#each data.edits as edit}
+                        <li>
+                            <strong>{new Date(edit.createdAt).toLocaleString()}</strong>
+                            by @{edit.editor?.name || "unknown"}
+                            {#if edit.isAdminEdit}(administrator){/if}
+                            {#if edit.restoredEditId}(restoration){/if}
+                            <details>
+                                <summary>View changes</summary>
+                                <p><strong>Title:</strong> {edit.previousTitle} → {edit.newTitle}</p>
+                                <p><strong>Previous description:</strong></p>
+                                <pre>{edit.previousDescription}</pre>
+                                <p><strong>New description:</strong></p>
+                                <pre>{edit.newDescription}</pre>
+                                {#if data.isAdmin}
+                                    <form
+                                        use:enhance={() => {
+                                            return async ({ result, update }) => {
+                                                await update();
+                                                if (result.type === "success") {
+                                                    showHistoryDialog = false;
+                                                }
+                                            };
+                                        }}
+                                        action="?/revertEdit"
+                                        method="POST"
+                                    >
+                                        <input
+                                            type="hidden"
+                                            name="editId"
+                                            value={edit.id}
+                                        />
+                                        <button type="submit">Revert this edit</button>
+                                    </form>
+                                {/if}
+                            </details>
+                        </li>
+                    {/each}
+                </ol>
+                <button type="button" on:click={() => (showHistoryDialog = false)}
+                    >Close</button
+                >
+            </Modal>
+        {/if}
     {/if}
 
     {#if data.user && (data.isAdmin || data.user.id === data.audio.user?.id)}
@@ -553,4 +667,37 @@
         color: #333;
         padding: 0.25rem 0;
     }
+
+    .edited-tag {
+        font-size: 0.65em;
+        font-weight: normal;
+    }
+
+    .edit-form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-top: 1rem;
+    }
+
+    .edit-form input,
+    .edit-form textarea {
+        padding: 0.5rem;
+        box-sizing: border-box;
+        width: 100%;
+    }
+
+    .edit-form textarea {
+        min-height: 8rem;
+    }
+
+    .edit-history pre {
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+    }
+
+    .form-message {
+        color: #a00;
+    }
+
 </style>


### PR DESCRIPTION
## Summary

- Allow audio owners to edit titles and descriptions up to three times
- Keep an immutable edit history, with unlimited administrative edits
- Show editing and history in accessible dialogs
- Add recent audio edits and revert actions to the admin panel
- Show an `[edited]` marker to administrators

## Validation

- `npm run check`
- `npm run build`

Closes #24