### PR TITLE
Let admins pin audios as announcements on the upload page

### DIFF
--- a/src/lib/server/database/migrations/20260818000003-add-audio-announcements.cjs
+++ b/src/lib/server/database/migrations/20260818000003-add-audio-announcements.cjs
@@ -1,0 +1,25 @@
+"use strict";
+
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn("Audios", "isAnnouncement", {
+            allowNull: false,
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        });
+        await queryInterface.addIndex("Audios", ["isAnnouncement"], {
+            name: "audios_is_announcement",
+        });
+    },
+
+    async down(queryInterface) {
+        // Raw DDL on purpose: queryInterface.removeColumn throws
+        // "Cannot delete property 'meta' of [object Array]" with the mariadb
+        // driver this project pins. Dropping the column also drops the index
+        // that covers only it, so removeIndex is unnecessary.
+        await queryInterface.sequelize.query(
+            "ALTER TABLE `Audios` DROP COLUMN `isAnnouncement`",
+        );
+    },
+};

--- a/src/lib/server/database/models/audio.ts
+++ b/src/lib/server/database/models/audio.ts
@@ -90,6 +90,15 @@ export default class Audio extends Model {
     @Column(DataType.BOOLEAN)
     declare isFromAi: boolean;
 
+    /**
+     * Admin-only notice. Announcements are pinned to the top of the upload
+     * page so uploaders see them before submitting anything.
+     */
+    @AllowNull(false)
+    @Default(false)
+    @Column(DataType.BOOLEAN)
+    declare isAnnouncement: boolean;
+
     @ForeignKey(() => User)
     @Column(DataType.UUID)
     declare userId: string;
@@ -180,6 +189,7 @@ export default class Audio extends Model {
             favoriteCount: favoriteCount ?? 0,
             isFavorited: isFavorited,
             createdAt: this.createdAt.getTime(),
+            isAnnouncement: this.isAnnouncement,
             user: includeUser ? this.user?.toClientside() : undefined,
         };
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,6 +70,8 @@ export interface ClientsideAudio {
     favoriteCount: number;
     isFavorited?: boolean;
     createdAt: number;
+    /** Admin-authored notice pinned to the top of the upload page. */
+    isAnnouncement: boolean;
     user?: ClientsideUser;
     comments?: ClientsideComment[];
 }

--- a/src/routes/listen/[id]/+page.server.ts
+++ b/src/routes/listen/[id]/+page.server.ts
@@ -297,6 +297,22 @@ export const actions: Actions = {
 
         return { editSuccess: true };
     },
+    setAnnouncement: async (event) => {
+        const user = event.locals.user;
+        if (!user || !user.isAdmin) {
+            return error(403, "Forbidden");
+        }
+        const audio = await Audio.findByPk(event.params.id);
+        if (!audio) {
+            return error(404, "Not found");
+        }
+        const form = await event.request.formData();
+        // The button posts the state it wants, so the action stays idempotent
+        // and a double submit cannot flip it back.
+        audio.isAnnouncement = form.get("isAnnouncement") === "on";
+        await audio.save();
+        return { announcementSuccess: true };
+    },
     delete: async (event) => {
         const user = event.locals.user;
         const audio = await Audio.findByPk(event.params.id, { include: User });

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -161,8 +161,17 @@
 
 <h1>
     {data.audio.title}
+    {#if data.audio.isAnnouncement}<span class="announcement-tag"
+            >[announcement]</span
+        >{/if}
     {#if data.hasEdits}<span class="edited-tag">[edited]</span>{/if}
 </h1>
+
+{#if data.audio.isAnnouncement}
+    <p class="announcement-note" role="note">
+        This audio is pinned to the top of the upload page as an announcement.
+    </p>
+{/if}
 
 <div class="audio-player">
     <AudioPlayer
@@ -389,6 +398,25 @@
                 >
             </Modal>
         {/if}
+    {/if}
+
+    {#if data.isAdmin}
+        <form use:enhance action="?/setAnnouncement" method="POST">
+            <!-- A plain button that states the action it performs, rather
+                 than a checkbox the admin has to remember to save. -->
+            <input
+                type="hidden"
+                name="isAnnouncement"
+                value={data.audio.isAnnouncement ? "off" : "on"}
+            />
+            <button type="submit">
+                {#if data.audio.isAnnouncement}
+                    Unpin as announcement
+                {:else}
+                    Pin as announcement on the upload page
+                {/if}
+            </button>
+        </form>
     {/if}
 
     {#if data.user && (data.isAdmin || data.user.id === data.audio.user?.id)}
@@ -671,6 +699,22 @@
     .edited-tag {
         font-size: 0.65em;
         font-weight: normal;
+    }
+
+    .announcement-tag {
+        font-size: 0.65em;
+        font-weight: normal;
+        color: #856404;
+    }
+
+    .announcement-note {
+        margin: 0 auto 1rem;
+        max-width: 700px;
+        padding: 0.5rem 0.75rem;
+        background: #fff3cd;
+        border: 1px solid #ffeeba;
+        border-radius: 4px;
+        color: #856404;
     }
 
     .edit-form {

--- a/src/routes/upload/+page.server.ts
+++ b/src/routes/upload/+page.server.ts
@@ -20,15 +20,30 @@ import fs from "fs/promises";
 import path from "path";
 import { error, fail, redirect } from "@sveltejs/kit";
 import type { Actions, PageServerLoad } from "./$types";
-import { Audio, Notification, Subscription } from "$lib/server/database";
+import { Audio, Notification, Subscription, User } from "$lib/server/database";
 import transcode from "$lib/server/transcode";
 import { NotificationTargetType, NotificationType } from "$lib/types";
 
-export const load: PageServerLoad = (event) => {
+export const load: PageServerLoad = async (event) => {
     const user = event.locals.user;
     if (!user) {
         return redirect(303, "/login");
     }
+
+    // Admin notices are pinned above the form so uploaders read them before
+    // submitting anything.
+    const announcements = await Audio.findAll({
+        where: { isAnnouncement: true, hasFile: true },
+        include: [User],
+        order: [["createdAt", "DESC"]],
+    });
+
+    return {
+        announcements: announcements.map((audio) => ({
+            ...audio.toClientside(),
+            mimeType: audio.mimeType,
+        })),
+    };
 };
 
 export const actions: Actions = {
@@ -59,6 +74,9 @@ export const actions: Actions = {
         const file = form.get("file") as File;
         const title = form.get("title") as string;
         const description = form.get("description") as string;
+        // Only admins may pin an audio; the checkbox is not rendered for others
+        // and is ignored here even if it is forged.
+        const isAnnouncement = user.isAdmin && form.get("isAnnouncement") === "on";
         if (!file) {
             return fail(400, { title, description });
         }
@@ -81,6 +99,7 @@ export const actions: Actions = {
             hasFile: true,
             userId: user.id,
             extension: path.extname(file.name),
+            isAnnouncement,
         });
         await fs.writeFile(audio.path, Buffer.from(await file.arrayBuffer()));
         transcode(audio.path).catch(async (err) => {

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -20,11 +20,41 @@
     import { enhance } from "$app/forms";
     import title from "$lib/title";
     import { onMount } from "svelte";
+    import AudioPlayer from "$lib/components/audio_player.svelte";
+    import SafeMarkdown from "$lib/components/safe_markdown.svelte";
+
+    export let data;
+
     onMount(() => title.set("Upload Audio"));
     let submitting = false;
+
+    $: announcements = data.announcements ?? [];
 </script>
 
 <h1>Upload Audio</h1>
+
+{#if announcements.length > 0}
+    <section class="announcements" aria-label="Announcements from the administrators">
+        <h2>Please read before uploading</h2>
+        {#each announcements as announcement (announcement.id)}
+            <article class="announcement">
+                <h3>
+                    <a href="/listen/{announcement.id}">{announcement.title}</a>
+                </h3>
+                <AudioPlayer
+                    preload="none"
+                    sources={[
+                        { src: `/${announcement.path}`, type: announcement.mimeType },
+                        { src: `/${announcement.transcodedPath}`, type: "audio/aac" },
+                    ]}
+                />
+                {#if announcement.description}
+                    <SafeMarkdown source={announcement.description} />
+                {/if}
+            </article>
+        {/each}
+    </section>
+{/if}
 
 <form
     use:enhance={() => {
@@ -87,6 +117,21 @@
         Please follow common decency and the law. Moderators and admins reserve
         the right to remove any content that is deemed inappropriate or illegal.
     </p>
+    {#if data.isAdmin}
+        <div class="form-group">
+            <!-- A switch rather than a plain checkbox, and still a real form
+                 control so the upload works without JavaScript. -->
+            <label class="announcement-toggle" for="isAnnouncement">
+                <input
+                    type="checkbox"
+                    role="switch"
+                    id="isAnnouncement"
+                    name="isAnnouncement"
+                />
+                Pin this audio as an announcement at the top of this page
+            </label>
+        </div>
+    {/if}
     <button type="submit" class="btn" disabled={submitting}
         >{#if submitting}Uploading...{:else}Upload{/if}</button
     >
@@ -151,6 +196,39 @@
         margin: 0.35rem 0 0;
         font-size: 0.85rem;
         color: #666;
+    }
+
+    .announcements {
+        max-width: 600px;
+        margin: 0 auto 1.5rem;
+        padding: 1rem;
+        border: 1px solid #ffeeba;
+        border-radius: 8px;
+        background-color: #fff3cd;
+        color: #856404;
+    }
+
+    .announcements h2 {
+        margin-top: 0;
+        font-size: 1.1rem;
+    }
+
+    .announcement + .announcement {
+        margin-top: 1rem;
+        padding-top: 1rem;
+        border-top: 1px solid #ffeeba;
+    }
+
+    .announcement h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1rem;
+    }
+
+    .announcement-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-weight: normal;
     }
 
     .btn {


### PR DESCRIPTION
## Summary

- Let admins pin an audio as an announcement, both at upload time and later from its detail page
- List active announcements at the top of the upload page, with a player and their description, so uploaders read them before submitting anything
- Mark pinned audios with an `[announcement]` tag and a note on their detail page

## Notes

The upload control is only rendered for admins, and the server ignores a forged `isAnnouncement` field from anyone else. The detail page control is a plain button that states the action it performs, rather than a checkbox the admin has to remember to save, and it posts the state it wants so a double submit cannot flip it back.

The migration's `down()` uses raw `ALTER TABLE ... DROP COLUMN` instead of `queryInterface.removeColumn`, which throws with the pinned mariadb driver. See #36, since it affects existing migrations too.

## Validation

- `npm run check` — 0 errors and 0 warnings
- `npm run build`
- Migration applied and rolled back

Part of #35
