### PR TITLE
Add emoji reactions to comments and stream chat

### DIFF
--- a/src/lib/components/comment.svelte
+++ b/src/lib/components/comment.svelte
@@ -24,6 +24,7 @@
   import SafeMarkdown from "./safe_markdown.svelte";
   import { updated } from "$app/state";
   import CommentList from "./comment_list.svelte";
+  import ReactionBar from "./reaction_bar.svelte";
 
   export let comment: ClientsideComment;
   export let user: ClientsideUser | undefined = undefined;
@@ -31,6 +32,10 @@
   export let onReply: ((comment: ClientsideComment) => void) = comment => {};
   let isDeletionModalVisible: boolean = false;
   let replyDisabled: boolean = false;
+
+  // Banned or unverified users see the tally but cannot add to it, which
+  // mirrors what the server enforces.
+  $: canReact = Boolean(user && user.isVerified && !user.isBanned);
 
   $: commentDate = comment
     ? formatRelative(new Date(comment.createdAt), new Date())
@@ -43,6 +48,14 @@
     <span class="comment-date"> - {commentDate}</span>
   </h3>
   <SafeMarkdown source={comment.content} />
+
+  <ReactionBar
+    targetId={comment.id}
+    reactions={comment.reactions ?? []}
+    formAction="?/react_comment"
+    {canReact}
+    label="Reactions to this comment"
+  />
 
   <div id="comment-actions">
     {#if user}

--- a/src/lib/components/reaction_bar.svelte
+++ b/src/lib/components/reaction_bar.svelte
@@ -1,0 +1,236 @@
+<!--
+  This file is part of the audiopub project.
+
+  Copyright (C) 2024 the-byte-bender
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<script lang="ts">
+    import { enhance } from "$app/forms";
+    import { REACTION_KINDS, reactionLabel } from "$lib/reactions";
+    import type { ClientsideReaction } from "$lib/types";
+
+    /** Current tally for this target. Emojis with no reactions are omitted. */
+    export let reactions: ClientsideReaction[] = [];
+    /** Identifies the comment or chat message being reacted to. */
+    export let targetId: string;
+    /**
+     * When set, the bar posts to this form action (works without JavaScript).
+     * Otherwise `onReact` is called and the caller handles the request.
+     */
+    export let formAction: string | null = null;
+    export let onReact: ((emoji: string) => void | Promise<void>) | null = null;
+    /** Logged out or unverified viewers still see the tally, read only. */
+    export let canReact: boolean = false;
+    export let label: string = "Reactions";
+
+    // Only emojis somebody actually used get a chip. The rest live behind the
+    // picker, so a comment with no reactions costs one button instead of six.
+    $: used = reactions.filter((r) => r.count > 0);
+    $: unused = REACTION_KINDS.filter(
+        (kind) => !used.some((r) => r.emoji === kind.emoji),
+    );
+
+    /**
+     * The chip's accessible name. Count and state are passed in as arguments
+     * on purpose: Svelte derives an expression's dependencies from the
+     * expression itself, so a value read only inside the function body would
+     * leave the label stale after the tally changes.
+     */
+    function chipLabel(emoji: string, count: number, reacted: boolean): string {
+        const name = reactionLabel(emoji);
+        const tally = count === 1 ? "1 reaction" : `${count} reactions`;
+        return reacted
+            ? `${name}, ${tally}, including yours. Activate to remove your reaction`
+            : `${name}, ${tally}. Activate to react`;
+    }
+</script>
+
+{#if canReact}
+    {#if formAction}
+        <form
+            class="reaction-bar"
+            method="POST"
+            action={formAction}
+            aria-label={label}
+            use:enhance={() => {
+                return async ({ update }) => {
+                    await update({ reset: false });
+                };
+            }}
+        >
+            <input type="hidden" name="targetId" value={targetId} />
+            {#each used as reaction (reaction.emoji)}
+                <button
+                    type="submit"
+                    name="emoji"
+                    value={reaction.emoji}
+                    class="reaction"
+                    class:active={reaction.reacted}
+                    aria-pressed={reaction.reacted}
+                    aria-label={chipLabel(
+                        reaction.emoji,
+                        reaction.count,
+                        reaction.reacted,
+                    )}
+                >
+                    <span aria-hidden="true">{reaction.emoji}</span>
+                    <span aria-hidden="true" class="count">{reaction.count}</span
+                    >
+                </button>
+            {/each}
+            {#if unused.length > 0}
+                <details class="picker">
+                    <summary>Add reaction</summary>
+                    <div class="picker-options">
+                        {#each unused as kind (kind.emoji)}
+                            <button
+                                type="submit"
+                                name="emoji"
+                                value={kind.emoji}
+                                class="reaction"
+                                aria-label="React with {kind.label}"
+                            >
+                                <span aria-hidden="true">{kind.emoji}</span>
+                            </button>
+                        {/each}
+                    </div>
+                </details>
+            {/if}
+        </form>
+    {:else}
+        <div class="reaction-bar" role="group" aria-label={label}>
+            {#each used as reaction (reaction.emoji)}
+                <button
+                    type="button"
+                    class="reaction"
+                    class:active={reaction.reacted}
+                    aria-pressed={reaction.reacted}
+                    aria-label={chipLabel(
+                        reaction.emoji,
+                        reaction.count,
+                        reaction.reacted,
+                    )}
+                    on:click={() => onReact && onReact(reaction.emoji)}
+                >
+                    <span aria-hidden="true">{reaction.emoji}</span>
+                    <span aria-hidden="true" class="count">{reaction.count}</span
+                    >
+                </button>
+            {/each}
+            {#if unused.length > 0}
+                <details class="picker">
+                    <summary>Add reaction</summary>
+                    <div class="picker-options">
+                        {#each unused as kind (kind.emoji)}
+                            <button
+                                type="button"
+                                class="reaction"
+                                aria-label="React with {kind.label}"
+                                on:click={() => onReact && onReact(kind.emoji)}
+                            >
+                                <span aria-hidden="true">{kind.emoji}</span>
+                            </button>
+                        {/each}
+                    </div>
+                </details>
+            {/if}
+        </div>
+    {/if}
+{:else if used.length > 0}
+    <p class="reaction-bar" aria-label={label}>
+        {#each used as reaction (reaction.emoji)}
+            <span
+                class="reaction static"
+                aria-label={chipLabel(
+                    reaction.emoji,
+                    reaction.count,
+                    reaction.reacted,
+                )}
+                ><span aria-hidden="true">{reaction.emoji}</span>
+                <span aria-hidden="true" class="count">{reaction.count}</span
+                ></span
+            >
+        {/each}
+    </p>
+{/if}
+
+<style>
+    .reaction-bar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.25rem;
+        margin: 0.35rem 0 0;
+    }
+
+    .reaction {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.2rem;
+        padding: 0.1rem 0.4rem;
+        border: 1px solid #ccc;
+        border-radius: 999px;
+        background: #fff;
+        font-size: 0.9rem;
+        line-height: 1.4;
+        cursor: pointer;
+    }
+
+    .reaction:hover {
+        border-color: #007bff;
+    }
+
+    .reaction.active {
+        border-color: #007bff;
+        background: #e7f1ff;
+        font-weight: 600;
+    }
+
+    .reaction.static {
+        cursor: default;
+    }
+
+    .count {
+        font-size: 0.8em;
+        color: #555;
+    }
+
+    .picker > summary {
+        display: inline-block;
+        padding: 0.1rem 0.4rem;
+        border: 1px solid #ccc;
+        border-radius: 999px;
+        background: #fff;
+        font-size: 0.8rem;
+        color: #555;
+        cursor: pointer;
+        list-style: none;
+    }
+
+    .picker > summary::-webkit-details-marker {
+        display: none;
+    }
+
+    .picker > summary:hover {
+        border-color: #007bff;
+    }
+
+    .picker-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+        margin-top: 0.25rem;
+    }
+</style>

--- a/src/lib/components/reaction_bar.svelte
+++ b/src/lib/components/reaction_bar.svelte
@@ -48,9 +48,19 @@
      * expression itself, so a value read only inside the function body would
      * leave the label stale after the tally changes.
      */
-    function chipLabel(emoji: string, count: number, reacted: boolean): string {
+    function chipLabel(
+        emoji: string,
+        count: number,
+        reacted: boolean,
+        interactive: boolean = true,
+    ): string {
         const name = reactionLabel(emoji);
         const tally = count === 1 ? "1 reaction" : `${count} reactions`;
+        // A read only viewer has nothing to activate, so the label stops at
+        // the tally instead of offering an action they cannot take.
+        if (!interactive) {
+            return `${name}, ${tally}`;
+        }
         return reacted
             ? `${name}, ${tally}, including yours. Activate to remove your reaction`
             : `${name}, ${tally}. Activate to react`;
@@ -149,7 +159,7 @@
         </div>
     {/if}
 {:else if used.length > 0}
-    <p class="reaction-bar" aria-label={label}>
+    <p class="reaction-bar" role="group" aria-label={label}>
         {#each used as reaction (reaction.emoji)}
             <span
                 class="reaction static"
@@ -157,6 +167,7 @@
                     reaction.emoji,
                     reaction.count,
                     reaction.reacted,
+                    false,
                 )}
                 ><span aria-hidden="true">{reaction.emoji}</span>
                 <span aria-hidden="true" class="count">{reaction.count}</span

--- a/src/lib/components/stream_chat.svelte
+++ b/src/lib/components/stream_chat.svelte
@@ -21,6 +21,7 @@
     import { formatRelative } from "date-fns";
     import SafeMarkdown from "./safe_markdown.svelte";
     import Modal from "./modal.svelte";
+    import ReactionBar from "./reaction_bar.svelte";
 
     export let chat: ClientsideStreamChat;
     export let isAdmin: boolean = false;
@@ -30,6 +31,9 @@
         | null = null;
     export let streamOwnerId: string | null = null;
     export let currentUser: ClientsideUser | null = null;
+    export let onReact:
+        | ((chat: ClientsideStreamChat, emoji: string) => void)
+        | null = null;
 
     let isDeletionModalVisible: boolean = false;
     let isMuteModalVisible: boolean = false;
@@ -41,6 +45,9 @@
         onDelete !== null && (isOwnMessage || isStreamOwner || isAdmin);
     $: canMute = onMute !== null && (isStreamOwner || isAdmin);
     $: chatDate = formatRelative(new Date(chat.createdAt), new Date());
+    $: canReact = Boolean(
+        onReact && currentUser && currentUser.isVerified && !currentUser.isBanned,
+    );
 
     function confirmMute() {
         const duration =
@@ -59,6 +66,16 @@
         <span class="chat-date">{chatDate}</span>
     </h3>
     <SafeMarkdown source={chat.content} />
+
+    <ReactionBar
+        targetId={chat.id}
+        reactions={chat.reactions ?? []}
+        onReact={(emoji) => {
+            onReact?.(chat, emoji);
+        }}
+        {canReact}
+        label="Reactions to this message"
+    />
 
     {#if canMute}
         <button on:click={() => (isMuteModalVisible = true)}>Mute Sender</button>

--- a/src/lib/components/stream_chat_list.svelte
+++ b/src/lib/components/stream_chat_list.svelte
@@ -32,6 +32,9 @@
         | ((chat: ClientsideStreamChat, durationMinutes: number | null) => void)
         | null = null;
     export let streamOwnerId: string | null = null;
+    export let onReact:
+        | ((chat: ClientsideStreamChat, emoji: string) => void)
+        | null = null;
     export let notice: string = "";
 
     let messageText = "";
@@ -68,6 +71,7 @@
                 {onDelete}
                 {onMute}
                 {streamOwnerId}
+                {onReact}
                 currentUser={user}
             />
         {:else}

--- a/src/lib/reactions.ts
+++ b/src/lib/reactions.ts
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2024 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The fixed set of reactions users can leave on comments and stream chat
+ * messages. Keeping it fixed keeps the UI predictable for screen reader users
+ * and avoids having to sanitize arbitrary user supplied emoji.
+ */
+export interface ReactionKind {
+    emoji: string;
+    /** Used as the accessible name of the reaction button. */
+    label: string;
+}
+
+export const REACTION_KINDS: ReactionKind[] = [
+    { emoji: "\u{1F44D}", label: "Like" },
+    { emoji: "\u{2764}\u{FE0F}", label: "Love" },
+    { emoji: "\u{1F602}", label: "Funny" },
+    { emoji: "\u{1F62E}", label: "Wow" },
+    { emoji: "\u{1F622}", label: "Sad" },
+    { emoji: "\u{1F525}", label: "Fire" },
+];
+
+export const REACTION_EMOJIS: string[] = REACTION_KINDS.map((k) => k.emoji);
+
+export function isValidReactionEmoji(emoji: unknown): emoji is string {
+    return typeof emoji === "string" && REACTION_EMOJIS.includes(emoji);
+}
+
+export function reactionLabel(emoji: string): string {
+    return REACTION_KINDS.find((k) => k.emoji === emoji)?.label ?? emoji;
+}

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -30,6 +30,7 @@ import StreamChat from "./models/stream_chat";
 import StreamMute from "./models/stream_mute";
 import Subscription from "./models/subscription"
 import AudioEdit from "./models/audio_edit";
+import Reaction from "./models/reaction";
 dotenv.config();
 
 if (
@@ -47,7 +48,7 @@ const database = new Sequelize({
     dialect: "mariadb",
     username: process.env.DATABASE_USER,
     password: process.env.DATABASE_PASSWORD,
-    models: [User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit],
+    models: [User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit, Reaction],
     logging: false,
     host: "127.0.0.1",
     port: 3306,
@@ -55,4 +56,4 @@ const database = new Sequelize({
 
 export default database;
 
-export { User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit };
+export { User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit, Reaction };

--- a/src/lib/server/database/migrations/20260818000001-add-reactions.cjs
+++ b/src/lib/server/database/migrations/20260818000001-add-reactions.cjs
@@ -1,0 +1,55 @@
+"use strict";
+
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable("Reactions", {
+            id: {
+                allowNull: false,
+                primaryKey: true,
+                type: Sequelize.UUID,
+                defaultValue: Sequelize.UUIDV4,
+            },
+            userId: {
+                allowNull: false,
+                type: Sequelize.UUID,
+                references: { model: "Users", key: "id" },
+                onDelete: "CASCADE",
+                onUpdate: "CASCADE",
+            },
+            // Polymorphic target: "comment" or "stream_chat". Not a real FK,
+            // so deletions are cleaned up by the application.
+            targetType: {
+                allowNull: false,
+                type: Sequelize.STRING(32),
+            },
+            targetId: {
+                allowNull: false,
+                type: Sequelize.UUID,
+            },
+            emoji: {
+                allowNull: false,
+                type: Sequelize.STRING(16),
+            },
+            createdAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+            updatedAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+        });
+
+        await queryInterface.addIndex(
+            "Reactions",
+            ["userId", "targetType", "targetId"],
+            { unique: true, name: "uniq_reaction_user_target" },
+        );
+        await queryInterface.addIndex("Reactions", ["targetType", "targetId"]);
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable("Reactions");
+    },
+};

--- a/src/lib/server/database/migrations/20260818000003-add-audio-announcements.cjs
+++ b/src/lib/server/database/migrations/20260818000003-add-audio-announcements.cjs
@@ -1,0 +1,25 @@
+"use strict";
+
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn("Audios", "isAnnouncement", {
+            allowNull: false,
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        });
+        await queryInterface.addIndex("Audios", ["isAnnouncement"], {
+            name: "audios_is_announcement",
+        });
+    },
+
+    async down(queryInterface) {
+        // Raw DDL on purpose: queryInterface.removeColumn throws
+        // "Cannot delete property 'meta' of [object Array]" with the mariadb
+        // driver this project pins. Dropping the column also drops the index
+        // that covers only it, so removeIndex is unnecessary.
+        await queryInterface.sequelize.query(
+            "ALTER TABLE `Audios` DROP COLUMN `isAnnouncement`",
+        );
+    },
+};

--- a/src/lib/server/database/models/audio.ts
+++ b/src/lib/server/database/models/audio.ts
@@ -90,6 +90,15 @@ export default class Audio extends Model {
     @Column(DataType.BOOLEAN)
     declare isFromAi: boolean;
 
+    /**
+     * Admin-only notice. Announcements are pinned to the top of the upload
+     * page so uploaders see them before submitting anything.
+     */
+    @AllowNull(false)
+    @Default(false)
+    @Column(DataType.BOOLEAN)
+    declare isAnnouncement: boolean;
+
     @ForeignKey(() => User)
     @Column(DataType.UUID)
     declare userId: string;
@@ -180,6 +189,7 @@ export default class Audio extends Model {
             favoriteCount: favoriteCount ?? 0,
             isFavorited: isFavorited,
             createdAt: this.createdAt.getTime(),
+            isAnnouncement: this.isAnnouncement,
             user: includeUser ? this.user?.toClientside() : undefined,
         };
     }

--- a/src/lib/server/database/models/comment.ts
+++ b/src/lib/server/database/models/comment.ts
@@ -36,7 +36,11 @@ import {
 } from "sequelize-typescript";
 import Audio from "./audio";
 import User from "./user";
-import type { ClientsideComment, ClientsideAudio } from "$lib/types";
+import type {
+  ClientsideComment,
+  ClientsideAudio,
+  ClientsideReaction,
+} from "$lib/types";
 
 @Table
 export default class Comment extends Model {
@@ -83,7 +87,10 @@ export default class Comment extends Model {
   public countReplies!: () => Promise<number>;
   toClientside(
     includeAudio: boolean = false,
-    includeReplies: boolean = false
+    includeReplies: boolean = false,
+    // Reactions are aggregated separately (one batched query for the whole
+    // thread) and handed in here keyed by comment id.
+    reactions?: Map<string, ClientsideReaction[]>
   ): ClientsideComment {
     return {
       id: this.id,
@@ -93,8 +100,11 @@ export default class Comment extends Model {
       user: this.user!.toClientside(),
       audio: includeAudio ? this.audio?.toClientside() : undefined,
       replies: includeReplies
-        ? this.replies?.map((r) => r.toClientside(includeAudio, includeReplies))
+        ? this.replies?.map((r) =>
+            r.toClientside(includeAudio, includeReplies, reactions)
+          )
         : undefined,
+      reactions: reactions?.get(this.id) ?? [],
     };
   }
 

--- a/src/lib/server/database/models/reaction.ts
+++ b/src/lib/server/database/models/reaction.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of the audiopub project.
  *
- * Copyright (C) 2026 the-byte-bender
+ * Copyright (C) 2024 the-byte-bender
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -26,58 +26,55 @@ import {
     Default,
     ForeignKey,
     BelongsTo,
+    Index,
+    Unique,
     CreatedAt,
     UpdatedAt,
 } from "sequelize-typescript";
 import User from "./user";
-import Stream from "./stream";
-import type { ClientsideStreamChat, ClientsideReaction } from "$lib/types";
+import { ReactionTargetType } from "$lib/types";
 
+/**
+ * A single reaction left by a user. Reactions are polymorphic: the same table
+ * backs comment reactions and stream chat reactions, discriminated by
+ * `targetType`. A user may only hold one reaction per target at a time;
+ * picking a different emoji replaces the previous one.
+ */
 @Table
-export default class StreamChat extends Model {
+export default class Reaction extends Model {
     @PrimaryKey
     @AllowNull(false)
     @Default(DataType.UUIDV4)
     @Column(DataType.UUID)
     declare id: string;
 
-    @ForeignKey(() => Stream)
-    @Column(DataType.UUID)
-    declare streamId: string;
-
-    @BelongsTo(() => Stream)
-    declare stream?: Stream;
-
+    @AllowNull(false)
+    @Unique("uniq_reaction_user_target")
     @ForeignKey(() => User)
+    @Index
     @Column(DataType.UUID)
     declare userId: string;
 
-    @BelongsTo(() => User)
+    @BelongsTo(() => User, { foreignKey: "userId", onDelete: "CASCADE" })
     declare user?: User;
 
     @AllowNull(false)
-    @Column(DataType.TEXT)
-    declare content: string;
+    @Unique("uniq_reaction_user_target")
+    @Column(DataType.STRING(32))
+    declare targetType: ReactionTargetType;
+
+    @AllowNull(false)
+    @Unique("uniq_reaction_user_target")
+    @Column(DataType.UUID)
+    declare targetId: string;
+
+    @AllowNull(false)
+    @Column(DataType.STRING(16))
+    declare emoji: string;
 
     @CreatedAt
     declare createdAt: Date;
 
     @UpdatedAt
     declare updatedAt: Date;
-
-    toClientside(
-        includeStream: boolean = false,
-        reactions: ClientsideReaction[] = [],
-    ): ClientsideStreamChat {
-        return {
-            id: this.id,
-            content: this.content,
-            createdAt: this.createdAt.getTime(),
-            user: this.user!.toClientside(),
-            stream: includeStream
-                ? this.stream?.toClientside(false)
-                : undefined,
-            reactions,
-        };
-    }
 }

--- a/src/lib/server/reactions.ts
+++ b/src/lib/server/reactions.ts
@@ -1,0 +1,138 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2024 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Reaction } from "$lib/server/database";
+import { Op } from "sequelize";
+import { isValidReactionEmoji } from "$lib/reactions";
+import { ReactionTargetType, type ClientsideReaction } from "$lib/types";
+
+export class InvalidReactionError extends Error {
+    constructor() {
+        super("Unknown reaction");
+        this.name = "InvalidReactionError";
+    }
+}
+
+/**
+ * Applies a user's reaction to a target.
+ *
+ * Passing the emoji the user already reacted with removes the reaction, which
+ * is what makes each reaction button a toggle. Passing a different emoji
+ * replaces the previous one, since a user holds at most one reaction per
+ * target. Returns the fresh summary from that user's point of view.
+ */
+export async function toggleReaction(
+    userId: string,
+    targetType: ReactionTargetType,
+    targetId: string,
+    emoji: string,
+): Promise<ClientsideReaction[]> {
+    if (!isValidReactionEmoji(emoji)) {
+        throw new InvalidReactionError();
+    }
+
+    const existing = await Reaction.findOne({
+        where: { userId, targetType, targetId },
+    });
+
+    if (existing && existing.emoji === emoji) {
+        await existing.destroy();
+    } else if (existing) {
+        existing.emoji = emoji;
+        await existing.save();
+    } else {
+        try {
+            await Reaction.create({ userId, targetType, targetId, emoji });
+        } catch (error) {
+            // Two rapid clicks can race on the unique index; the first one won,
+            // and that is a perfectly good outcome.
+            if ((error as any)?.name !== "SequelizeUniqueConstraintError") {
+                throw error;
+            }
+        }
+    }
+
+    const summaries = await summarizeReactions(targetType, [targetId], userId);
+    return summaries.get(targetId) ?? [];
+}
+
+/**
+ * Aggregates reactions for a batch of targets in a single query, so a page
+ * full of comments does not turn into one query per comment.
+ */
+export async function summarizeReactions(
+    targetType: ReactionTargetType,
+    targetIds: string[],
+    viewerId?: string | null,
+): Promise<Map<string, ClientsideReaction[]>> {
+    const result = new Map<string, ClientsideReaction[]>();
+    if (targetIds.length === 0) {
+        return result;
+    }
+
+    const rows = await Reaction.findAll({
+        where: { targetType, targetId: { [Op.in]: targetIds } },
+        attributes: ["targetId", "emoji", "userId"],
+        raw: true,
+    });
+
+    const counts = new Map<string, Map<string, number>>();
+    const mine = new Map<string, string>();
+
+    for (const row of rows as unknown as {
+        targetId: string;
+        emoji: string;
+        userId: string;
+    }[]) {
+        let perTarget = counts.get(row.targetId);
+        if (!perTarget) {
+            perTarget = new Map<string, number>();
+            counts.set(row.targetId, perTarget);
+        }
+        perTarget.set(row.emoji, (perTarget.get(row.emoji) ?? 0) + 1);
+        if (viewerId && row.userId === viewerId) {
+            mine.set(row.targetId, row.emoji);
+        }
+    }
+
+    for (const [targetId, perTarget] of counts) {
+        const summary: ClientsideReaction[] = [...perTarget.entries()]
+            .map(([emoji, count]) => ({
+                emoji,
+                count,
+                reacted: mine.get(targetId) === emoji,
+            }))
+            // Most reacted first, then alphabetically so the order is stable
+            // between renders.
+            .sort((a, b) => b.count - a.count || a.emoji.localeCompare(b.emoji));
+        result.set(targetId, summary);
+    }
+
+    return result;
+}
+
+/**
+ * Drops reactions whose target no longer exists. Reactions are polymorphic and
+ * therefore have no foreign key to cascade from.
+ */
+export async function deleteReactionsFor(
+    targetType: ReactionTargetType,
+    targetId: string,
+): Promise<void> {
+    await Reaction.destroy({ where: { targetType, targetId } });
+}

--- a/src/lib/server/streaming.ts
+++ b/src/lib/server/streaming.ts
@@ -24,7 +24,11 @@ import { EventEmitter } from "node:events";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import type { ClientsideStreamChat, ClientsideStreamMute } from "$lib/types";
+import type {
+    ClientsideStreamChat,
+    ClientsideStreamMute,
+    ClientsideReaction,
+} from "$lib/types";
 import { StreamState, StreamFormat } from "$lib/types";
 
 const execFileAsync = promisify(execFile);
@@ -57,6 +61,27 @@ export class StreamingService extends EventEmitter {
             streamId,
             chatId,
         } as StreamChatDeletedEvent);
+    }
+
+    /**
+     * Reaction tallies are shared by everyone, but "did I react" is not, so the
+     * broadcast carries the actor and their new emoji and each client folds its
+     * own state in.
+     */
+    notifyChatReaction(
+        streamId: string,
+        chatId: string,
+        reactions: ClientsideReaction[],
+        actorId: string,
+        emoji: string | null,
+    ) {
+        this.emit(STREAM_CHAT_REACTION, {
+            streamId,
+            chatId,
+            reactions,
+            actorId,
+            emoji,
+        } as StreamChatReactionEvent);
     }
 
     notifyStateChanged(
@@ -574,6 +599,7 @@ export const STREAM_ARCHIVED = "stream:archived";
 export const STREAM_DESTROYED = "stream:destroyed";
 export const STREAM_LISTENERS_CHANGED = "stream:listeners_changed";
 export const STREAM_MODERATION_CHANGED = "stream:moderation_changed";
+export const STREAM_CHAT_REACTION = "stream:chat_reaction";
 
 export interface StreamEvent {
     streamId: string;
@@ -590,6 +616,15 @@ export interface StreamChatSentEvent extends StreamEvent {
 
 export interface StreamChatDeletedEvent extends StreamEvent {
     chatId: string;
+}
+
+export interface StreamChatReactionEvent extends StreamEvent {
+    chatId: string;
+    /** Shared tally; the `reacted` flags in it are meaningless to other viewers. */
+    reactions: ClientsideReaction[];
+    actorId: string;
+    /** The actor's reaction after the change, or null when they removed it. */
+    emoji: string | null;
 }
 
 export interface StreamListenersChangedEvent extends StreamEvent {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,6 +70,8 @@ export interface ClientsideAudio {
     favoriteCount: number;
     isFavorited?: boolean;
     createdAt: number;
+    /** Admin-authored notice pinned to the top of the upload page. */
+    isAnnouncement: boolean;
     user?: ClientsideUser;
     comments?: ClientsideComment[];
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,19 @@ export interface ClientsideUser {
     isTrusted: boolean;
 }
 
+export enum ReactionTargetType {
+    comment = "comment",
+    streamChat = "stream_chat",
+}
+
+/** Aggregated reactions for one target, from the point of view of a viewer. */
+export interface ClientsideReaction {
+    emoji: string;
+    count: number;
+    /** True when the requesting user is one of the reactors. */
+    reacted: boolean;
+}
+
 export interface ClientsideStream {
     id: string;
     title: string;
@@ -45,6 +58,7 @@ export interface ClientsideStreamChat {
     createdAt: number;
     user: ClientsideUser;
     stream?: ClientsideStream;
+    reactions?: ClientsideReaction[];
 }
 
 export interface ClientsideStreamMute {
@@ -84,6 +98,7 @@ export interface ClientsideComment {
     user: ClientsideUser;
     audio?: ClientsideAudio;
     replies?: ClientsideComment[];
+    reactions?: ClientsideReaction[];
 }
 
 export enum NotificationType {

--- a/src/routes/listen/[id]/+page.server.ts
+++ b/src/routes/listen/[id]/+page.server.ts
@@ -41,6 +41,13 @@ import {
     MAX_USER_AUDIO_EDITS,
     updateAudioDetails,
 } from "$lib/server/audio_edits";
+import {
+    InvalidReactionError,
+    deleteReactionsFor,
+    summarizeReactions,
+    toggleReaction,
+} from "$lib/server/reactions";
+import { ReactionTargetType } from "$lib/types";
 
 export const load: PageServerLoad = async (event) => {
     const audio = await Audio.findByPk(event.params.id, {
@@ -102,6 +109,12 @@ export const load: PageServerLoad = async (event) => {
             { where: whereClause },
         );
     }
+
+    const commentReactions = await summarizeReactions(
+        ReactionTargetType.comment,
+        comments.map((c) => c.id),
+        viewer?.id,
+    );
 
     const sortedComments = Comment.constructThreads(comments);
     const canEdit = Boolean(
@@ -185,7 +198,9 @@ export const load: PageServerLoad = async (event) => {
 
     return {
         audio: audio.toClientside(true, favoriteCount, isFavorited),
-        comments: sortedComments.map((c) => c.toClientside(false, true)),
+        comments: sortedComments.map((c) =>
+            c.toClientside(false, true, commentReactions),
+        ),
         mimeType: audio.mimeType,
         isFollowing,
         archivedStreamId: audio.archivedStreamId,
@@ -194,7 +209,16 @@ export const load: PageServerLoad = async (event) => {
                   where: { streamId: audio.archivedStreamId },
                   include: { model: User },
                   order: [["createdAt", "ASC"]],
-              }).then((chats) => chats.map((c) => c.toClientside()))
+              }).then(async (chats) => {
+                  const reactions = await summarizeReactions(
+                      ReactionTargetType.streamChat,
+                      chats.map((c) => c.id),
+                      viewer?.id,
+                  );
+                  return chats.map((c) =>
+                      c.toClientside(false, reactions.get(c.id) ?? []),
+                  );
+              })
             : null,
         isSubscribed,
         canEdit,
@@ -296,6 +320,40 @@ export const actions: Actions = {
         }
 
         return { editSuccess: true };
+    },
+    react_comment: async (event) => {
+        const user = event.locals.user;
+        if (!user || !user.isVerified || user.isBanned) {
+            return error(403, "Forbidden");
+        }
+
+        const form = await event.request.formData();
+        const targetId = form.get("targetId");
+        const emoji = form.get("emoji");
+        if (typeof targetId !== "string" || typeof emoji !== "string") {
+            return fail(400, { reactionMessage: "Invalid reaction" });
+        }
+
+        const comment = await Comment.findByPk(targetId);
+        if (!comment || comment.audioId !== event.params.id) {
+            return error(404, "Not found");
+        }
+
+        try {
+            await toggleReaction(
+                user.id,
+                ReactionTargetType.comment,
+                comment.id,
+                emoji,
+            );
+        } catch (err) {
+            if (err instanceof InvalidReactionError) {
+                return fail(400, { reactionMessage: "Unknown reaction" });
+            }
+            throw err;
+        }
+
+        return { success: true };
     },
     setAnnouncement: async (event) => {
         const user = event.locals.user;
@@ -425,6 +483,7 @@ export const actions: Actions = {
 
         // Otherwise we can just delete it
         await comment.destroy();
+        await deleteReactionsFor(ReactionTargetType.comment, comment.id);
         return { success: true };
     },
     follow: async (event) => {

--- a/src/routes/listen/[id]/+page.server.ts
+++ b/src/routes/listen/[id]/+page.server.ts
@@ -297,6 +297,22 @@ export const actions: Actions = {
 
         return { editSuccess: true };
     },
+    setAnnouncement: async (event) => {
+        const user = event.locals.user;
+        if (!user || !user.isAdmin) {
+            return error(403, "Forbidden");
+        }
+        const audio = await Audio.findByPk(event.params.id);
+        if (!audio) {
+            return error(404, "Not found");
+        }
+        const form = await event.request.formData();
+        // The button posts the state it wants, so the action stays idempotent
+        // and a double submit cannot flip it back.
+        audio.isAnnouncement = form.get("isAnnouncement") === "on";
+        await audio.save();
+        return { announcementSuccess: true };
+    },
     delete: async (event) => {
         const user = event.locals.user;
         const audio = await Audio.findByPk(event.params.id, { include: User });

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -161,8 +161,17 @@
 
 <h1>
     {data.audio.title}
+    {#if data.audio.isAnnouncement}<span class="announcement-tag"
+            >[announcement]</span
+        >{/if}
     {#if data.hasEdits}<span class="edited-tag">[edited]</span>{/if}
 </h1>
+
+{#if data.audio.isAnnouncement}
+    <p class="announcement-note" role="note">
+        This audio is pinned to the top of the upload page as an announcement.
+    </p>
+{/if}
 
 <div class="audio-player">
     <AudioPlayer
@@ -389,6 +398,25 @@
                 >
             </Modal>
         {/if}
+    {/if}
+
+    {#if data.isAdmin}
+        <form use:enhance action="?/setAnnouncement" method="POST">
+            <!-- A plain button that states the action it performs, rather
+                 than a checkbox the admin has to remember to save. -->
+            <input
+                type="hidden"
+                name="isAnnouncement"
+                value={data.audio.isAnnouncement ? "off" : "on"}
+            />
+            <button type="submit">
+                {#if data.audio.isAnnouncement}
+                    Unpin as announcement
+                {:else}
+                    Pin as announcement on the upload page
+                {/if}
+            </button>
+        </form>
     {/if}
 
     {#if data.user && (data.isAdmin || data.user.id === data.audio.user?.id)}
@@ -671,6 +699,22 @@
     .edited-tag {
         font-size: 0.65em;
         font-weight: normal;
+    }
+
+    .announcement-tag {
+        font-size: 0.65em;
+        font-weight: normal;
+        color: #856404;
+    }
+
+    .announcement-note {
+        margin: 0 auto 1rem;
+        max-width: 700px;
+        padding: 0.5rem 0.75rem;
+        background: #fff3cd;
+        border: 1px solid #ffeeba;
+        border-radius: 4px;
+        color: #856404;
     }
 
     .edit-form {

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -25,7 +25,11 @@
     import StreamChatList from "$lib/components/stream_chat_list.svelte";
     import title from "$lib/title";
     import SafeMarkdown from "$lib/components/safe_markdown.svelte";
-    import type { ClientsideComment } from "$lib/types.js";
+    import type {
+        ClientsideComment,
+        ClientsideStreamChat,
+    } from "$lib/types.js";
+    import { invalidateAll } from "$app/navigation";
     import SubscribeButton from "$lib/components/subscribe_button.svelte";
     import AudioPlayer from "$lib/components/audio_player.svelte";
     import Modal from "$lib/components/modal.svelte";
@@ -135,6 +139,24 @@
     let commentField: HTMLTextAreaElement;
     function onReply(comment: ClientsideComment) {
         commentField.focus();
+    }
+
+    async function onArchivedChatReact(
+        chat: ClientsideStreamChat,
+        emoji: string,
+    ) {
+        const res = await fetch(
+            `/live/${data.archivedStreamId}/${chat.id}`,
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ emoji }),
+            },
+        );
+        if (res.ok) {
+            // The archived page has no live connection, so reload the tally.
+            await invalidateAll();
+        }
     }
 
     function onShareClick() {
@@ -448,6 +470,7 @@
                 user={data.user ?? undefined}
                 isAdmin={data.isAdmin}
                 streamOwnerId={data.audio.user?.id ?? null}
+                onReact={onArchivedChatReact}
                 onDelete={async (chatId) => {
                     await fetch(`/live/${data.archivedStreamId}/${chatId}`, {
                         method: "DELETE",

--- a/src/routes/live/[id]/+page.server.ts
+++ b/src/routes/live/[id]/+page.server.ts
@@ -26,7 +26,8 @@ import {
 import { error, redirect } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 import { Op } from "sequelize";
-import type { ClientsideStreamMute } from "$lib/types";
+import { ReactionTargetType, type ClientsideStreamMute } from "$lib/types";
+import { summarizeReactions } from "$lib/server/reactions";
 
 export const load: PageServerLoad = async (event) => {
     const stream = await Stream.findByPk(event.params.id, {
@@ -73,9 +74,18 @@ export const load: PageServerLoad = async (event) => {
         }));
     }
 
+    const chats = stream.streamChats ?? [];
+    const chatReactions = await summarizeReactions(
+        ReactionTargetType.streamChat,
+        chats.map((c) => c.id),
+        viewer?.id,
+    );
+
     return {
         stream: stream.toClientside(true),
-        chats: stream.streamChats?.map((c) => c.toClientside()),
+        chats: chats.map((c) =>
+            c.toClientside(false, chatReactions.get(c.id) ?? []),
+        ),
         mutes,
         slowModeSeconds: stream.slowModeSeconds,
     };

--- a/src/routes/live/[id]/+page.svelte
+++ b/src/routes/live/[id]/+page.svelte
@@ -31,6 +31,7 @@
     import type {
         ClientsideStreamChat,
         ClientsideStreamMute,
+        ClientsideReaction,
     } from "$lib/types";
 
     onMount(() => title.set(data.stream.title));
@@ -75,6 +76,36 @@
         }, durationMs);
     }
 
+    async function handleChatReaction(
+        chat: ClientsideStreamChat,
+        emoji: string,
+    ) {
+        try {
+            const res = await fetch(`/live/${data.stream.id}/${chat.id}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ emoji }),
+            });
+            if (!res.ok) {
+                setChatNotice("Could not save your reaction.");
+                return;
+            }
+            const body = await res.json();
+            applyChatReactions(chat.id, body.reactions as ClientsideReaction[]);
+        } catch {
+            setChatNotice("Could not save your reaction.");
+        }
+    }
+
+    function applyChatReactions(
+        chatId: string,
+        reactions: ClientsideReaction[],
+    ) {
+        chats = chats.map((c) =>
+            c.id === chatId ? { ...c, reactions } : c,
+        );
+    }
+
     function connectSSE() {
         eventSource = new EventSource(`/live/${data.stream.id}/events`);
 
@@ -104,6 +135,23 @@
             const chat = JSON.parse(e.data) as ClientsideStreamChat;
             chats = [...chats.filter((c) => c.id !== chat.id), chat];
             handleNewChat(chat);
+        });
+
+        eventSource.addEventListener("chat_reaction", (e) => {
+            const d = JSON.parse(e.data);
+            const reactions = (d.reactions ?? []) as ClientsideReaction[];
+            // The broadcast tally has no notion of "mine"; recompute it from
+            // the actor when it was us, and keep our previous flags otherwise.
+            const mine =
+                d.actorId === data.user?.id
+                    ? (d.emoji as string | null)
+                    : (chats
+                          .find((c) => c.id === d.chatId)
+                          ?.reactions?.find((r) => r.reacted)?.emoji ?? null);
+            applyChatReactions(
+                d.chatId,
+                reactions.map((r) => ({ ...r, reacted: r.emoji === mine })),
+            );
         });
 
         eventSource.addEventListener("chat_delete", (e) => {
@@ -413,6 +461,7 @@
     isAdmin={data.isAdmin}
     onDelete={handleDeleteChat}
     onMute={handleMute}
+    onReact={handleChatReaction}
     streamOwnerId={data.stream.user?.id ?? null}
     onSendMessage={handleSendMessage}
     notice={chatNotice}

--- a/src/routes/live/[id]/[chatId]/+server.ts
+++ b/src/routes/live/[id]/[chatId]/+server.ts
@@ -20,6 +20,12 @@ import { json, error } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { StreamChat, Stream } from "$lib/server/database";
 import { streamingService } from "$lib/server/streaming";
+import {
+    InvalidReactionError,
+    deleteReactionsFor,
+    toggleReaction,
+} from "$lib/server/reactions";
+import { ReactionTargetType } from "$lib/types";
 
 export const DELETE: RequestHandler = async (event) => {
     const user = event.locals.user;
@@ -42,6 +48,67 @@ export const DELETE: RequestHandler = async (event) => {
     }
 
     await chat.destroy();
+    await deleteReactionsFor(ReactionTargetType.streamChat, chat.id);
     streamingService.notifyChatDeleted(stream.id, chat.id);
     return json({ success: true });
+};
+
+/**
+ * Toggles the caller's reaction on a chat message. This also works after the
+ * stream is archived, so the chat history on the audio page stays interactive.
+ */
+export const POST: RequestHandler = async (event) => {
+    const user = event.locals.user;
+    if (!user) {
+        return json({ message: "You must be logged in" }, { status: 401 });
+    }
+    if (user.isBanned) {
+        return json({ message: "You are banned" }, { status: 403 });
+    }
+    if (!user.isVerified) {
+        return json(
+            { message: "Please verify your email before reacting" },
+            { status: 403 },
+        );
+    }
+
+    const chatId = event.params.chatId;
+    if (!chatId) {
+        return json({ message: "Missing chat ID" }, { status: 400 });
+    }
+
+    const chat = await StreamChat.findByPk(chatId, { include: Stream });
+    if (!chat) {
+        return json({ message: "Not found" }, { status: 404 });
+    }
+
+    let body: any;
+    try {
+        body = await event.request.json();
+    } catch {
+        return json({ message: "Invalid request" }, { status: 400 });
+    }
+
+    try {
+        const reactions = await toggleReaction(
+            user.id,
+            ReactionTargetType.streamChat,
+            chat.id,
+            body?.emoji,
+        );
+        const mine = reactions.find((r) => r.reacted)?.emoji ?? null;
+        streamingService.notifyChatReaction(
+            chat.streamId,
+            chat.id,
+            reactions,
+            user.id,
+            mine,
+        );
+        return json({ reactions });
+    } catch (err) {
+        if (err instanceof InvalidReactionError) {
+            return json({ message: "Unknown reaction" }, { status: 400 });
+        }
+        throw err;
+    }
 };

--- a/src/routes/live/[id]/events/+server.ts
+++ b/src/routes/live/[id]/events/+server.ts
@@ -26,6 +26,7 @@ import {
     STREAM_CHAT_DELETED,
     STREAM_ARCHIVED,
     STREAM_MODERATION_CHANGED,
+    STREAM_CHAT_REACTION,
 } from "$lib/server/streaming";
 import type {
     StreamStateChangedEvent,
@@ -34,6 +35,7 @@ import type {
     StreamChatDeletedEvent,
     StreamArchivedEvent,
     StreamModerationChangedEvent,
+    StreamChatReactionEvent,
 } from "$lib/server/streaming";
 
 export const GET: RequestHandler = async (event) => {
@@ -84,6 +86,17 @@ export const GET: RequestHandler = async (event) => {
         }
     };
 
+    const onChatReaction = (data: StreamChatReactionEvent) => {
+        if (data.streamId === stream.id) {
+            send("chat_reaction", {
+                chatId: data.chatId,
+                reactions: data.reactions,
+                actorId: data.actorId,
+                emoji: data.emoji,
+            });
+        }
+    };
+
     const onModerationChanged = (data: StreamModerationChangedEvent) => {
         if (data.streamId === stream.id) {
             send("moderation", {
@@ -128,6 +141,7 @@ export const GET: RequestHandler = async (event) => {
             streamingService.on(STREAM_CHAT_DELETED, onChatDeleted);
             streamingService.on(STREAM_ARCHIVED, onArchived);
             streamingService.on(STREAM_MODERATION_CHANGED, onModerationChanged);
+            streamingService.on(STREAM_CHAT_REACTION, onChatReaction);
 
             keepalive = setInterval(() => {
                 try {
@@ -146,6 +160,7 @@ export const GET: RequestHandler = async (event) => {
             streamingService.off(STREAM_CHAT_DELETED, onChatDeleted);
             streamingService.off(STREAM_ARCHIVED, onArchived);
             streamingService.off(STREAM_MODERATION_CHANGED, onModerationChanged);
+            streamingService.off(STREAM_CHAT_REACTION, onChatReaction);
             streamingService.listenerDisconnected(stream.id);
         },
     });

--- a/src/routes/upload/+page.server.ts
+++ b/src/routes/upload/+page.server.ts
@@ -20,15 +20,30 @@ import fs from "fs/promises";
 import path from "path";
 import { error, fail, redirect } from "@sveltejs/kit";
 import type { Actions, PageServerLoad } from "./$types";
-import { Audio, Notification, Subscription } from "$lib/server/database";
+import { Audio, Notification, Subscription, User } from "$lib/server/database";
 import transcode from "$lib/server/transcode";
 import { NotificationTargetType, NotificationType } from "$lib/types";
 
-export const load: PageServerLoad = (event) => {
+export const load: PageServerLoad = async (event) => {
     const user = event.locals.user;
     if (!user) {
         return redirect(303, "/login");
     }
+
+    // Admin notices are pinned above the form so uploaders read them before
+    // submitting anything.
+    const announcements = await Audio.findAll({
+        where: { isAnnouncement: true, hasFile: true },
+        include: [User],
+        order: [["createdAt", "DESC"]],
+    });
+
+    return {
+        announcements: announcements.map((audio) => ({
+            ...audio.toClientside(),
+            mimeType: audio.mimeType,
+        })),
+    };
 };
 
 export const actions: Actions = {
@@ -59,6 +74,9 @@ export const actions: Actions = {
         const file = form.get("file") as File;
         const title = form.get("title") as string;
         const description = form.get("description") as string;
+        // Only admins may pin an audio; the checkbox is not rendered for others
+        // and is ignored here even if it is forged.
+        const isAnnouncement = user.isAdmin && form.get("isAnnouncement") === "on";
         if (!file) {
             return fail(400, { title, description });
         }
@@ -81,6 +99,7 @@ export const actions: Actions = {
             hasFile: true,
             userId: user.id,
             extension: path.extname(file.name),
+            isAnnouncement,
         });
         await fs.writeFile(audio.path, Buffer.from(await file.arrayBuffer()));
         transcode(audio.path).catch(async (err) => {

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -20,11 +20,41 @@
     import { enhance } from "$app/forms";
     import title from "$lib/title";
     import { onMount } from "svelte";
+    import AudioPlayer from "$lib/components/audio_player.svelte";
+    import SafeMarkdown from "$lib/components/safe_markdown.svelte";
+
+    export let data;
+
     onMount(() => title.set("Upload Audio"));
     let submitting = false;
+
+    $: announcements = data.announcements ?? [];
 </script>
 
 <h1>Upload Audio</h1>
+
+{#if announcements.length > 0}
+    <section class="announcements" aria-label="Announcements from the administrators">
+        <h2>Please read before uploading</h2>
+        {#each announcements as announcement (announcement.id)}
+            <article class="announcement">
+                <h3>
+                    <a href="/listen/{announcement.id}">{announcement.title}</a>
+                </h3>
+                <AudioPlayer
+                    preload="none"
+                    sources={[
+                        { src: `/${announcement.path}`, type: announcement.mimeType },
+                        { src: `/${announcement.transcodedPath}`, type: "audio/aac" },
+                    ]}
+                />
+                {#if announcement.description}
+                    <SafeMarkdown source={announcement.description} />
+                {/if}
+            </article>
+        {/each}
+    </section>
+{/if}
 
 <form
     use:enhance={() => {
@@ -87,6 +117,21 @@
         Please follow common decency and the law. Moderators and admins reserve
         the right to remove any content that is deemed inappropriate or illegal.
     </p>
+    {#if data.isAdmin}
+        <div class="form-group">
+            <!-- A switch rather than a plain checkbox, and still a real form
+                 control so the upload works without JavaScript. -->
+            <label class="announcement-toggle" for="isAnnouncement">
+                <input
+                    type="checkbox"
+                    role="switch"
+                    id="isAnnouncement"
+                    name="isAnnouncement"
+                />
+                Pin this audio as an announcement at the top of this page
+            </label>
+        </div>
+    {/if}
     <button type="submit" class="btn" disabled={submitting}
         >{#if submitting}Uploading...{:else}Upload{/if}</button
     >
@@ -151,6 +196,39 @@
         margin: 0.35rem 0 0;
         font-size: 0.85rem;
         color: #666;
+    }
+
+    .announcements {
+        max-width: 600px;
+        margin: 0 auto 1.5rem;
+        padding: 1rem;
+        border: 1px solid #ffeeba;
+        border-radius: 8px;
+        background-color: #fff3cd;
+        color: #856404;
+    }
+
+    .announcements h2 {
+        margin-top: 0;
+        font-size: 1.1rem;
+    }
+
+    .announcement + .announcement {
+        margin-top: 1rem;
+        padding-top: 1rem;
+        border-top: 1px solid #ffeeba;
+    }
+
+    .announcement h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1rem;
+    }
+
+    .announcement-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-weight: normal;
     }
 
     .btn {


### PR DESCRIPTION
## Summary

- Add a fixed set of six emoji reactions to audio comments and to stream chat, live and archived
- Store them in one polymorphic table, so the same component serves both targets
- Only render a chip for emojis somebody actually used; the rest sit behind a collapsed picker, so an untouched comment costs one control instead of six
- Broadcast new tallies over SSE on live streams

## Notes

Each chip carries its tally and the viewer's own state in its accessible name, so a screen reader user hears "Fire, 1 reaction, including yours. Activate to remove your reaction" rather than having to infer it from the pressed state alone.

On the comments page the bar posts to a form action, so it works without JavaScript. In a live stream it goes through `fetch`. "Did I react" is per viewer and is never broadcast; each client folds its own state in from the actor id on the event.

## Stacked on #32

This branch is based on #32, so its diff currently includes that commit as well. I will rebase once #32 is resolved, either way. Marked as a draft until then.

## Validation

- `npm run check` — 0 errors and 0 warnings
- `npm run build`
- Migration applied and rolled back
- Reacting, un-reacting and switching emoji exercised on comments and on a live stream with two accounts

Part of #35
