### PR TITLE
Add polls to live streams

### DIFF
--- a/src/lib/components/comment.svelte
+++ b/src/lib/components/comment.svelte
@@ -24,6 +24,7 @@
   import SafeMarkdown from "./safe_markdown.svelte";
   import { updated } from "$app/state";
   import CommentList from "./comment_list.svelte";
+  import ReactionBar from "./reaction_bar.svelte";
 
   export let comment: ClientsideComment;
   export let user: ClientsideUser | undefined = undefined;
@@ -31,6 +32,10 @@
   export let onReply: ((comment: ClientsideComment) => void) = comment => {};
   let isDeletionModalVisible: boolean = false;
   let replyDisabled: boolean = false;
+
+  // Banned or unverified users see the tally but cannot add to it, which
+  // mirrors what the server enforces.
+  $: canReact = Boolean(user && user.isVerified && !user.isBanned);
 
   $: commentDate = comment
     ? formatRelative(new Date(comment.createdAt), new Date())
@@ -43,6 +48,14 @@
     <span class="comment-date"> - {commentDate}</span>
   </h3>
   <SafeMarkdown source={comment.content} />
+
+  <ReactionBar
+    targetId={comment.id}
+    reactions={comment.reactions ?? []}
+    formAction="?/react_comment"
+    {canReact}
+    label="Reactions to this comment"
+  />
 
   <div id="comment-actions">
     {#if user}

--- a/src/lib/components/reaction_bar.svelte
+++ b/src/lib/components/reaction_bar.svelte
@@ -1,0 +1,236 @@
+<!--
+  This file is part of the audiopub project.
+
+  Copyright (C) 2024 the-byte-bender
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<script lang="ts">
+    import { enhance } from "$app/forms";
+    import { REACTION_KINDS, reactionLabel } from "$lib/reactions";
+    import type { ClientsideReaction } from "$lib/types";
+
+    /** Current tally for this target. Emojis with no reactions are omitted. */
+    export let reactions: ClientsideReaction[] = [];
+    /** Identifies the comment or chat message being reacted to. */
+    export let targetId: string;
+    /**
+     * When set, the bar posts to this form action (works without JavaScript).
+     * Otherwise `onReact` is called and the caller handles the request.
+     */
+    export let formAction: string | null = null;
+    export let onReact: ((emoji: string) => void | Promise<void>) | null = null;
+    /** Logged out or unverified viewers still see the tally, read only. */
+    export let canReact: boolean = false;
+    export let label: string = "Reactions";
+
+    // Only emojis somebody actually used get a chip. The rest live behind the
+    // picker, so a comment with no reactions costs one button instead of six.
+    $: used = reactions.filter((r) => r.count > 0);
+    $: unused = REACTION_KINDS.filter(
+        (kind) => !used.some((r) => r.emoji === kind.emoji),
+    );
+
+    /**
+     * The chip's accessible name. Count and state are passed in as arguments
+     * on purpose: Svelte derives an expression's dependencies from the
+     * expression itself, so a value read only inside the function body would
+     * leave the label stale after the tally changes.
+     */
+    function chipLabel(emoji: string, count: number, reacted: boolean): string {
+        const name = reactionLabel(emoji);
+        const tally = count === 1 ? "1 reaction" : `${count} reactions`;
+        return reacted
+            ? `${name}, ${tally}, including yours. Activate to remove your reaction`
+            : `${name}, ${tally}. Activate to react`;
+    }
+</script>
+
+{#if canReact}
+    {#if formAction}
+        <form
+            class="reaction-bar"
+            method="POST"
+            action={formAction}
+            aria-label={label}
+            use:enhance={() => {
+                return async ({ update }) => {
+                    await update({ reset: false });
+                };
+            }}
+        >
+            <input type="hidden" name="targetId" value={targetId} />
+            {#each used as reaction (reaction.emoji)}
+                <button
+                    type="submit"
+                    name="emoji"
+                    value={reaction.emoji}
+                    class="reaction"
+                    class:active={reaction.reacted}
+                    aria-pressed={reaction.reacted}
+                    aria-label={chipLabel(
+                        reaction.emoji,
+                        reaction.count,
+                        reaction.reacted,
+                    )}
+                >
+                    <span aria-hidden="true">{reaction.emoji}</span>
+                    <span aria-hidden="true" class="count">{reaction.count}</span
+                    >
+                </button>
+            {/each}
+            {#if unused.length > 0}
+                <details class="picker">
+                    <summary>Add reaction</summary>
+                    <div class="picker-options">
+                        {#each unused as kind (kind.emoji)}
+                            <button
+                                type="submit"
+                                name="emoji"
+                                value={kind.emoji}
+                                class="reaction"
+                                aria-label="React with {kind.label}"
+                            >
+                                <span aria-hidden="true">{kind.emoji}</span>
+                            </button>
+                        {/each}
+                    </div>
+                </details>
+            {/if}
+        </form>
+    {:else}
+        <div class="reaction-bar" role="group" aria-label={label}>
+            {#each used as reaction (reaction.emoji)}
+                <button
+                    type="button"
+                    class="reaction"
+                    class:active={reaction.reacted}
+                    aria-pressed={reaction.reacted}
+                    aria-label={chipLabel(
+                        reaction.emoji,
+                        reaction.count,
+                        reaction.reacted,
+                    )}
+                    on:click={() => onReact && onReact(reaction.emoji)}
+                >
+                    <span aria-hidden="true">{reaction.emoji}</span>
+                    <span aria-hidden="true" class="count">{reaction.count}</span
+                    >
+                </button>
+            {/each}
+            {#if unused.length > 0}
+                <details class="picker">
+                    <summary>Add reaction</summary>
+                    <div class="picker-options">
+                        {#each unused as kind (kind.emoji)}
+                            <button
+                                type="button"
+                                class="reaction"
+                                aria-label="React with {kind.label}"
+                                on:click={() => onReact && onReact(kind.emoji)}
+                            >
+                                <span aria-hidden="true">{kind.emoji}</span>
+                            </button>
+                        {/each}
+                    </div>
+                </details>
+            {/if}
+        </div>
+    {/if}
+{:else if used.length > 0}
+    <p class="reaction-bar" aria-label={label}>
+        {#each used as reaction (reaction.emoji)}
+            <span
+                class="reaction static"
+                aria-label={chipLabel(
+                    reaction.emoji,
+                    reaction.count,
+                    reaction.reacted,
+                )}
+                ><span aria-hidden="true">{reaction.emoji}</span>
+                <span aria-hidden="true" class="count">{reaction.count}</span
+                ></span
+            >
+        {/each}
+    </p>
+{/if}
+
+<style>
+    .reaction-bar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.25rem;
+        margin: 0.35rem 0 0;
+    }
+
+    .reaction {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.2rem;
+        padding: 0.1rem 0.4rem;
+        border: 1px solid #ccc;
+        border-radius: 999px;
+        background: #fff;
+        font-size: 0.9rem;
+        line-height: 1.4;
+        cursor: pointer;
+    }
+
+    .reaction:hover {
+        border-color: #007bff;
+    }
+
+    .reaction.active {
+        border-color: #007bff;
+        background: #e7f1ff;
+        font-weight: 600;
+    }
+
+    .reaction.static {
+        cursor: default;
+    }
+
+    .count {
+        font-size: 0.8em;
+        color: #555;
+    }
+
+    .picker > summary {
+        display: inline-block;
+        padding: 0.1rem 0.4rem;
+        border: 1px solid #ccc;
+        border-radius: 999px;
+        background: #fff;
+        font-size: 0.8rem;
+        color: #555;
+        cursor: pointer;
+        list-style: none;
+    }
+
+    .picker > summary::-webkit-details-marker {
+        display: none;
+    }
+
+    .picker > summary:hover {
+        border-color: #007bff;
+    }
+
+    .picker-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+        margin-top: 0.25rem;
+    }
+</style>

--- a/src/lib/components/reaction_bar.svelte
+++ b/src/lib/components/reaction_bar.svelte
@@ -48,9 +48,19 @@
      * expression itself, so a value read only inside the function body would
      * leave the label stale after the tally changes.
      */
-    function chipLabel(emoji: string, count: number, reacted: boolean): string {
+    function chipLabel(
+        emoji: string,
+        count: number,
+        reacted: boolean,
+        interactive: boolean = true,
+    ): string {
         const name = reactionLabel(emoji);
         const tally = count === 1 ? "1 reaction" : `${count} reactions`;
+        // A read only viewer has nothing to activate, so the label stops at
+        // the tally instead of offering an action they cannot take.
+        if (!interactive) {
+            return `${name}, ${tally}`;
+        }
         return reacted
             ? `${name}, ${tally}, including yours. Activate to remove your reaction`
             : `${name}, ${tally}. Activate to react`;
@@ -149,7 +159,7 @@
         </div>
     {/if}
 {:else if used.length > 0}
-    <p class="reaction-bar" aria-label={label}>
+    <p class="reaction-bar" role="group" aria-label={label}>
         {#each used as reaction (reaction.emoji)}
             <span
                 class="reaction static"
@@ -157,6 +167,7 @@
                     reaction.emoji,
                     reaction.count,
                     reaction.reacted,
+                    false,
                 )}
                 ><span aria-hidden="true">{reaction.emoji}</span>
                 <span aria-hidden="true" class="count">{reaction.count}</span

--- a/src/lib/components/stream_chat.svelte
+++ b/src/lib/components/stream_chat.svelte
@@ -21,6 +21,7 @@
     import { formatRelative } from "date-fns";
     import SafeMarkdown from "./safe_markdown.svelte";
     import Modal from "./modal.svelte";
+    import ReactionBar from "./reaction_bar.svelte";
 
     export let chat: ClientsideStreamChat;
     export let isAdmin: boolean = false;
@@ -30,6 +31,9 @@
         | null = null;
     export let streamOwnerId: string | null = null;
     export let currentUser: ClientsideUser | null = null;
+    export let onReact:
+        | ((chat: ClientsideStreamChat, emoji: string) => void)
+        | null = null;
 
     let isDeletionModalVisible: boolean = false;
     let isMuteModalVisible: boolean = false;
@@ -41,6 +45,9 @@
         onDelete !== null && (isOwnMessage || isStreamOwner || isAdmin);
     $: canMute = onMute !== null && (isStreamOwner || isAdmin);
     $: chatDate = formatRelative(new Date(chat.createdAt), new Date());
+    $: canReact = Boolean(
+        onReact && currentUser && currentUser.isVerified && !currentUser.isBanned,
+    );
 
     function confirmMute() {
         const duration =
@@ -59,6 +66,16 @@
         <span class="chat-date">{chatDate}</span>
     </h3>
     <SafeMarkdown source={chat.content} />
+
+    <ReactionBar
+        targetId={chat.id}
+        reactions={chat.reactions ?? []}
+        onReact={(emoji) => {
+            onReact?.(chat, emoji);
+        }}
+        {canReact}
+        label="Reactions to this message"
+    />
 
     {#if canMute}
         <button on:click={() => (isMuteModalVisible = true)}>Mute Sender</button>

--- a/src/lib/components/stream_chat_list.svelte
+++ b/src/lib/components/stream_chat_list.svelte
@@ -32,6 +32,9 @@
         | ((chat: ClientsideStreamChat, durationMinutes: number | null) => void)
         | null = null;
     export let streamOwnerId: string | null = null;
+    export let onReact:
+        | ((chat: ClientsideStreamChat, emoji: string) => void)
+        | null = null;
     export let notice: string = "";
 
     let messageText = "";
@@ -68,6 +71,7 @@
                 {onDelete}
                 {onMute}
                 {streamOwnerId}
+                {onReact}
                 currentUser={user}
             />
         {:else}

--- a/src/lib/components/stream_polls.svelte
+++ b/src/lib/components/stream_polls.svelte
@@ -1,0 +1,579 @@
+<!--
+  This file is part of the audiopub project.
+
+  Copyright (C) 2024 the-byte-bender
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<script lang="ts">
+    import Modal from "./modal.svelte";
+    import { PollState, type ClientsidePoll } from "$lib/types";
+
+    export let streamId: string;
+    export let polls: ClientsidePoll[] = [];
+    /** Stream owner or admin: can create, close and delete polls. */
+    export let canManage: boolean = false;
+    export let canVote: boolean = false;
+    /** Archived streams show final results only. */
+    export let readOnly: boolean = false;
+    export let heading: string = "Polls";
+    export let onLocalUpdate: ((poll: ClientsidePoll) => void) | null = null;
+    export let onLocalDelete: ((pollId: string) => void) | null = null;
+
+    const MAX_OPTIONS = 6;
+
+    let showCreate = false;
+    let question = "";
+    let optionTexts: string[] = ["", ""];
+    let allowMultiple = false;
+    let hideResultsUntilVote = false;
+    let creating = false;
+    let notice = "";
+    /** Announced to screen readers when a tally or poll state changes. */
+    let liveMessage = "";
+    let busyPollId: string | null = null;
+
+    function resetForm() {
+        question = "";
+        optionTexts = ["", ""];
+        allowMultiple = false;
+        hideResultsUntilVote = false;
+        notice = "";
+    }
+
+    function addOption() {
+        if (optionTexts.length < MAX_OPTIONS) {
+            optionTexts = [...optionTexts, ""];
+        }
+    }
+
+    function removeOption(index: number) {
+        if (optionTexts.length > 2) {
+            optionTexts = optionTexts.filter((_, i) => i !== index);
+        }
+    }
+
+    async function readError(res: Response, fallback: string): Promise<string> {
+        try {
+            const body = await res.json();
+            if (typeof body?.message === "string") return body.message;
+        } catch {}
+        return fallback;
+    }
+
+    async function createPoll() {
+        creating = true;
+        notice = "";
+        try {
+            const res = await fetch(`/live/${streamId}/polls`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    question,
+                    options: optionTexts,
+                    allowMultiple,
+                    hideResultsUntilVote,
+                }),
+            });
+            if (!res.ok) {
+                notice = await readError(res, "Could not create the poll.");
+                return;
+            }
+            const body = await res.json();
+            onLocalUpdate?.(body.poll);
+            liveMessage = `Poll created: ${body.poll.question}`;
+            showCreate = false;
+            resetForm();
+        } catch {
+            notice = "Could not create the poll.";
+        } finally {
+            creating = false;
+        }
+    }
+
+    async function vote(poll: ClientsidePoll, optionId: string) {
+        busyPollId = poll.id;
+        try {
+            const res = await fetch(`/live/${streamId}/polls/${poll.id}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ optionId }),
+            });
+            if (!res.ok) {
+                liveMessage = await readError(
+                    res,
+                    "Could not register your vote.",
+                );
+                return;
+            }
+            const body = await res.json();
+            const updated = body.poll as ClientsidePoll;
+            onLocalUpdate?.(updated);
+            const chosen = updated.options.find((o) => o.id === optionId);
+            const name = chosen?.text ?? "your option";
+            liveMessage = updated.votedOptionIds.includes(optionId)
+                ? `Selected ${name}.`
+                : `Removed your vote for ${name}.`;
+        } catch {
+            liveMessage = "Could not register your vote.";
+        } finally {
+            busyPollId = null;
+        }
+    }
+
+    async function closePoll(poll: ClientsidePoll) {
+        busyPollId = poll.id;
+        try {
+            const res = await fetch(`/live/${streamId}/polls/${poll.id}`, {
+                method: "PUT",
+            });
+            if (!res.ok) {
+                liveMessage = await readError(res, "Could not close the poll.");
+                return;
+            }
+            const body = await res.json();
+            onLocalUpdate?.(body.poll);
+            liveMessage = `Poll closed: ${poll.question}`;
+        } catch {
+            liveMessage = "Could not close the poll.";
+        } finally {
+            busyPollId = null;
+        }
+    }
+
+    async function deletePoll(poll: ClientsidePoll) {
+        busyPollId = poll.id;
+        try {
+            const res = await fetch(`/live/${streamId}/polls/${poll.id}`, {
+                method: "DELETE",
+            });
+            if (!res.ok) {
+                liveMessage = await readError(res, "Could not delete the poll.");
+                return;
+            }
+            onLocalDelete?.(poll.id);
+            liveMessage = "Poll deleted.";
+        } catch {
+            liveMessage = "Could not delete the poll.";
+        } finally {
+            busyPollId = null;
+        }
+    }
+
+    function percentage(votes: number, total: number): number {
+        if (total <= 0) return 0;
+        return Math.round((votes / total) * 100);
+    }
+
+    function votesLabel(count: number): string {
+        return count === 1 ? "1 vote" : `${count} votes`;
+    }
+
+    function votersLabel(count: number): string {
+        return count === 1 ? "1 person voted" : `${count} people voted`;
+    }
+
+    /**
+     * The option's accessible name. Every reactive value it depends on is
+     * passed in as an argument: Svelte derives an expression's dependencies
+     * from the expression itself, so a value merely read inside the function
+     * body would not re-render the label when it changes.
+     */
+    function optionLabel(
+        text: string,
+        votes: number,
+        total: number,
+        selected: boolean,
+        hidden: boolean,
+        multiple: boolean,
+    ): string {
+        const parts = [text];
+        if (hidden) {
+            parts.push("results hidden");
+        } else {
+            parts.push(`${votesLabel(votes)}, ${percentage(votes, total)}%`);
+        }
+        if (selected) {
+            parts.push(multiple ? "selected" : "your vote");
+        }
+        return parts.join(", ");
+    }
+
+    function pollModeLabel(poll: ClientsidePoll): string {
+        const parts: string[] = [];
+        parts.push(
+            poll.allowMultiple
+                ? "Pick as many options as you like"
+                : "Pick one option",
+        );
+        if (poll.hideResultsUntilVote) {
+            parts.push("results hidden until you vote");
+        }
+        return parts.join(" — ");
+    }
+</script>
+
+{#if polls.length > 0 || (canManage && !readOnly)}
+    <section class="polls" aria-label={heading}>
+        <h2>{heading}</h2>
+
+        <p class="sr-only" aria-live="polite">{liveMessage}</p>
+
+        {#if canManage && !readOnly}
+            <button type="button" on:click={() => (showCreate = true)}>
+                Create poll
+            </button>
+
+            <Modal bind:visible={showCreate}>
+                <h2>Create a poll</h2>
+                {#if notice}
+                    <p class="poll-notice" role="alert">{notice}</p>
+                {/if}
+                <form on:submit|preventDefault={createPoll}>
+                    <label for="poll-question">Question:</label>
+                    <input
+                        id="poll-question"
+                        type="text"
+                        bind:value={question}
+                        required
+                        minlength="3"
+                        maxlength="300"
+                    />
+
+                    <fieldset>
+                        <legend>Options</legend>
+                        {#each optionTexts as _, index}
+                            <div class="poll-option-row">
+                                <label for="poll-option-{index}">
+                                    Option {index + 1}:
+                                </label>
+                                <input
+                                    id="poll-option-{index}"
+                                    type="text"
+                                    bind:value={optionTexts[index]}
+                                    maxlength="200"
+                                    required={index < 2}
+                                />
+                                {#if optionTexts.length > 2}
+                                    <button
+                                        type="button"
+                                        on:click={() => removeOption(index)}
+                                    >
+                                        Remove option {index + 1}
+                                    </button>
+                                {/if}
+                            </div>
+                        {/each}
+                        {#if optionTexts.length < MAX_OPTIONS}
+                            <button type="button" on:click={addOption}>
+                                Add option
+                            </button>
+                        {/if}
+                    </fieldset>
+
+                    <fieldset>
+                        <legend>Settings</legend>
+                        <label class="poll-setting" for="poll-allow-multiple">
+                            <input
+                                id="poll-allow-multiple"
+                                type="checkbox"
+                                role="switch"
+                                bind:checked={allowMultiple}
+                            />
+                            Allow more than one option per person
+                        </label>
+                        <label class="poll-setting" for="poll-hide-results">
+                            <input
+                                id="poll-hide-results"
+                                type="checkbox"
+                                role="switch"
+                                bind:checked={hideResultsUntilVote}
+                            />
+                            Hide results until the person votes
+                        </label>
+                        <p class="poll-setting-hint">
+                            Hidden results become visible to everyone once you
+                            close the poll.
+                        </p>
+                    </fieldset>
+
+                    <button type="submit" disabled={creating}>
+                        {#if creating}Creating...{:else}Create poll{/if}
+                    </button>
+                    <button
+                        type="button"
+                        on:click={() => {
+                            showCreate = false;
+                            resetForm();
+                        }}
+                    >
+                        Cancel
+                    </button>
+                </form>
+            </Modal>
+        {/if}
+
+        {#each polls as poll (poll.id)}
+            <article class="poll">
+                <h3>
+                    {poll.question}
+                    {#if poll.state === PollState.closed}
+                        <span class="poll-state">(closed)</span>
+                    {/if}
+                </h3>
+
+                {#if poll.state === PollState.open && !readOnly}
+                    <p class="poll-mode">{pollModeLabel(poll)}</p>
+                {/if}
+
+                <ul class="poll-options">
+                    {#each poll.options as option (option.id)}
+                        <li>
+                            {#if canVote && !readOnly && poll.state === PollState.open}
+                                <button
+                                    type="button"
+                                    class="poll-vote"
+                                    class:voted={poll.votedOptionIds.includes(
+                                        option.id,
+                                    )}
+                                    aria-pressed={poll.votedOptionIds.includes(
+                                        option.id,
+                                    )}
+                                    aria-label={optionLabel(
+                                        option.text,
+                                        option.votes,
+                                        poll.totalVotes,
+                                        poll.votedOptionIds.includes(option.id),
+                                        poll.resultsHidden,
+                                        poll.allowMultiple,
+                                    )}
+                                    disabled={busyPollId === poll.id}
+                                    on:click={() => vote(poll, option.id)}
+                                >
+                                    <span aria-hidden="true">
+                                        {option.text}
+                                        {#if !poll.resultsHidden}
+                                            — {votesLabel(option.votes)}
+                                            ({percentage(
+                                                option.votes,
+                                                poll.totalVotes,
+                                            )}%)
+                                        {/if}
+                                    </span>
+                                </button>
+                            {:else}
+                                <span
+                                    class="poll-result"
+                                    class:voted={poll.votedOptionIds.includes(
+                                        option.id,
+                                    )}
+                                >
+                                    {option.text}
+                                    {#if !poll.resultsHidden}
+                                        — {votesLabel(option.votes)}
+                                        ({percentage(
+                                            option.votes,
+                                            poll.totalVotes,
+                                        )}%)
+                                    {/if}
+                                    {#if poll.votedOptionIds.includes(option.id)}
+                                        <span class="your-vote">your vote</span>
+                                    {/if}
+                                </span>
+                            {/if}
+                        </li>
+                    {/each}
+                </ul>
+
+                {#if poll.resultsHidden}
+                    <p class="poll-total">
+                        Results are hidden until you vote.
+                    </p>
+                {:else}
+                    <p class="poll-total">{votersLabel(poll.totalVotes)}</p>
+                {/if}
+
+                {#if !canVote && !readOnly && poll.state === PollState.open}
+                    <p class="poll-hint">
+                        <a href="/login">Log in</a> to vote.
+                    </p>
+                {/if}
+
+                {#if canManage && !readOnly}
+                    <div class="poll-admin">
+                        {#if poll.state === PollState.open}
+                            <button
+                                type="button"
+                                disabled={busyPollId === poll.id}
+                                on:click={() => closePoll(poll)}
+                            >
+                                Close poll
+                            </button>
+                        {/if}
+                        <button
+                            type="button"
+                            disabled={busyPollId === poll.id}
+                            on:click={() => deletePoll(poll)}
+                        >
+                            Delete poll
+                        </button>
+                    </div>
+                {/if}
+            </article>
+        {:else}
+            <p class="no-polls">No polls yet.</p>
+        {/each}
+    </section>
+{/if}
+
+<style>
+    .polls {
+        margin-top: 1.5rem;
+        padding: 1rem;
+        background: #f9f9f9;
+        border-radius: 8px;
+    }
+
+    .polls h2 {
+        margin-top: 0;
+        font-size: 1.2rem;
+    }
+
+    .poll {
+        margin-top: 1rem;
+        padding: 0.75rem;
+        background: #fff;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+    }
+
+    .poll h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1.05rem;
+    }
+
+    .poll-state {
+        font-weight: normal;
+        color: #6c757d;
+        font-size: 0.9em;
+    }
+
+    .poll-mode {
+        margin: 0 0 0.5rem;
+        font-size: 0.85rem;
+        color: #6c757d;
+    }
+
+    .poll-options {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+    }
+
+    .poll-vote {
+        width: 100%;
+        text-align: left;
+        padding: 0.4rem 0.6rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background: #fff;
+        cursor: pointer;
+    }
+
+    .poll-vote:hover {
+        border-color: #007bff;
+    }
+
+    .poll-vote.voted,
+    .poll-result.voted {
+        border-color: #007bff;
+        background: #e7f1ff;
+        font-weight: 600;
+    }
+
+    .poll-result {
+        display: block;
+        padding: 0.4rem 0.6rem;
+        border: 1px solid #eee;
+        border-radius: 4px;
+    }
+
+    .your-vote {
+        font-size: 0.85em;
+        color: #0056b3;
+    }
+
+    .poll-total,
+    .poll-hint {
+        margin: 0.5rem 0 0;
+        font-size: 0.9rem;
+        color: #555;
+    }
+
+    .poll-notice {
+        padding: 0.5rem;
+        background: #fff3cd;
+        border: 1px solid #ffeeba;
+        border-radius: 4px;
+        color: #856404;
+    }
+
+    .poll-admin {
+        margin-top: 0.5rem;
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+    }
+
+    .poll-option-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 0.35rem;
+        flex-wrap: wrap;
+    }
+
+    .poll-setting {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        margin-bottom: 0.35rem;
+    }
+
+    .poll-setting-hint {
+        margin: 0.25rem 0 0;
+        font-size: 0.85rem;
+        color: #666;
+    }
+
+    .no-polls {
+        color: #666;
+        font-style: italic;
+    }
+
+    .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+</style>

--- a/src/lib/reactions.ts
+++ b/src/lib/reactions.ts
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2024 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The fixed set of reactions users can leave on comments and stream chat
+ * messages. Keeping it fixed keeps the UI predictable for screen reader users
+ * and avoids having to sanitize arbitrary user supplied emoji.
+ */
+export interface ReactionKind {
+    emoji: string;
+    /** Used as the accessible name of the reaction button. */
+    label: string;
+}
+
+export const REACTION_KINDS: ReactionKind[] = [
+    { emoji: "\u{1F44D}", label: "Like" },
+    { emoji: "\u{2764}\u{FE0F}", label: "Love" },
+    { emoji: "\u{1F602}", label: "Funny" },
+    { emoji: "\u{1F62E}", label: "Wow" },
+    { emoji: "\u{1F622}", label: "Sad" },
+    { emoji: "\u{1F525}", label: "Fire" },
+];
+
+export const REACTION_EMOJIS: string[] = REACTION_KINDS.map((k) => k.emoji);
+
+export function isValidReactionEmoji(emoji: unknown): emoji is string {
+    return typeof emoji === "string" && REACTION_EMOJIS.includes(emoji);
+}
+
+export function reactionLabel(emoji: string): string {
+    return REACTION_KINDS.find((k) => k.emoji === emoji)?.label ?? emoji;
+}

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -31,6 +31,9 @@ import StreamMute from "./models/stream_mute";
 import Subscription from "./models/subscription"
 import AudioEdit from "./models/audio_edit";
 import Reaction from "./models/reaction";
+import StreamPoll from "./models/stream_poll";
+import StreamPollOption from "./models/stream_poll_option";
+import StreamPollVote from "./models/stream_poll_vote";
 dotenv.config();
 
 if (
@@ -48,7 +51,7 @@ const database = new Sequelize({
     dialect: "mariadb",
     username: process.env.DATABASE_USER,
     password: process.env.DATABASE_PASSWORD,
-    models: [User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit, Reaction],
+    models: [User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit, Reaction, StreamPoll, StreamPollOption, StreamPollVote],
     logging: false,
     host: "127.0.0.1",
     port: 3306,
@@ -56,4 +59,4 @@ const database = new Sequelize({
 
 export default database;
 
-export { User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit, Reaction };
+export { User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit, Reaction, StreamPoll, StreamPollOption, StreamPollVote };

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -30,6 +30,7 @@ import StreamChat from "./models/stream_chat";
 import StreamMute from "./models/stream_mute";
 import Subscription from "./models/subscription"
 import AudioEdit from "./models/audio_edit";
+import Reaction from "./models/reaction";
 dotenv.config();
 
 if (
@@ -47,7 +48,7 @@ const database = new Sequelize({
     dialect: "mariadb",
     username: process.env.DATABASE_USER,
     password: process.env.DATABASE_PASSWORD,
-    models: [User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit],
+    models: [User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit, Reaction],
     logging: false,
     host: "127.0.0.1",
     port: 3306,
@@ -55,4 +56,4 @@ const database = new Sequelize({
 
 export default database;
 
-export { User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit };
+export { User, Audio, Comment, PlaysTracker, Notification, AudioFollow, AudioFavorite, Stream, StreamChat, StreamMute, Subscription, AudioEdit, Reaction };

--- a/src/lib/server/database/migrations/20260818000001-add-reactions.cjs
+++ b/src/lib/server/database/migrations/20260818000001-add-reactions.cjs
@@ -1,0 +1,55 @@
+"use strict";
+
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable("Reactions", {
+            id: {
+                allowNull: false,
+                primaryKey: true,
+                type: Sequelize.UUID,
+                defaultValue: Sequelize.UUIDV4,
+            },
+            userId: {
+                allowNull: false,
+                type: Sequelize.UUID,
+                references: { model: "Users", key: "id" },
+                onDelete: "CASCADE",
+                onUpdate: "CASCADE",
+            },
+            // Polymorphic target: "comment" or "stream_chat". Not a real FK,
+            // so deletions are cleaned up by the application.
+            targetType: {
+                allowNull: false,
+                type: Sequelize.STRING(32),
+            },
+            targetId: {
+                allowNull: false,
+                type: Sequelize.UUID,
+            },
+            emoji: {
+                allowNull: false,
+                type: Sequelize.STRING(16),
+            },
+            createdAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+            updatedAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+        });
+
+        await queryInterface.addIndex(
+            "Reactions",
+            ["userId", "targetType", "targetId"],
+            { unique: true, name: "uniq_reaction_user_target" },
+        );
+        await queryInterface.addIndex("Reactions", ["targetType", "targetId"]);
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable("Reactions");
+    },
+};

--- a/src/lib/server/database/migrations/20260818000002-add-stream-polls.cjs
+++ b/src/lib/server/database/migrations/20260818000002-add-stream-polls.cjs
@@ -1,0 +1,159 @@
+"use strict";
+
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable("StreamPolls", {
+            id: {
+                allowNull: false,
+                primaryKey: true,
+                type: Sequelize.UUID,
+                defaultValue: Sequelize.UUIDV4,
+            },
+            streamId: {
+                allowNull: false,
+                type: Sequelize.UUID,
+                references: { model: "Streams", key: "id" },
+                onDelete: "CASCADE",
+                onUpdate: "CASCADE",
+            },
+            createdById: {
+                allowNull: true,
+                type: Sequelize.UUID,
+                references: { model: "Users", key: "id" },
+                onDelete: "SET NULL",
+                onUpdate: "CASCADE",
+            },
+            question: {
+                allowNull: false,
+                type: Sequelize.TEXT,
+            },
+            state: {
+                allowNull: false,
+                type: Sequelize.STRING(16),
+                defaultValue: "open",
+            },
+            closedAt: {
+                allowNull: true,
+                type: Sequelize.DATE,
+            },
+            allowMultiple: {
+                allowNull: false,
+                type: Sequelize.BOOLEAN,
+                defaultValue: false,
+            },
+            hideResultsUntilVote: {
+                allowNull: false,
+                type: Sequelize.BOOLEAN,
+                defaultValue: false,
+            },
+            createdAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+            updatedAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+        });
+
+        await queryInterface.createTable("StreamPollOptions", {
+            id: {
+                allowNull: false,
+                primaryKey: true,
+                type: Sequelize.UUID,
+                defaultValue: Sequelize.UUIDV4,
+            },
+            pollId: {
+                allowNull: false,
+                type: Sequelize.UUID,
+                references: { model: "StreamPolls", key: "id" },
+                onDelete: "CASCADE",
+                onUpdate: "CASCADE",
+            },
+            text: {
+                allowNull: false,
+                type: Sequelize.STRING(200),
+            },
+            position: {
+                allowNull: false,
+                type: Sequelize.INTEGER,
+                defaultValue: 0,
+            },
+            voteCount: {
+                allowNull: false,
+                type: Sequelize.INTEGER,
+                defaultValue: 0,
+            },
+            createdAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+            updatedAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+        });
+
+        await queryInterface.createTable("StreamPollVotes", {
+            id: {
+                allowNull: false,
+                primaryKey: true,
+                type: Sequelize.UUID,
+                defaultValue: Sequelize.UUIDV4,
+            },
+            pollId: {
+                allowNull: false,
+                type: Sequelize.UUID,
+                references: { model: "StreamPolls", key: "id" },
+                onDelete: "CASCADE",
+                onUpdate: "CASCADE",
+            },
+            optionId: {
+                allowNull: false,
+                type: Sequelize.UUID,
+                references: { model: "StreamPollOptions", key: "id" },
+                onDelete: "CASCADE",
+                onUpdate: "CASCADE",
+            },
+            userId: {
+                allowNull: false,
+                type: Sequelize.UUID,
+                references: { model: "Users", key: "id" },
+                onDelete: "CASCADE",
+                onUpdate: "CASCADE",
+            },
+            createdAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+            updatedAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+            },
+        });
+
+        await queryInterface.addIndex("StreamPolls", ["streamId", "createdAt"]);
+        await queryInterface.addIndex("StreamPollOptions", [
+            "pollId",
+            "position",
+        ]);
+        // One row per selected option, so uniqueness spans the option too.
+        await queryInterface.addIndex(
+            "StreamPollVotes",
+            ["pollId", "userId", "optionId"],
+            { unique: true, name: "uniq_poll_vote_user_option" },
+        );
+        // Leads with pollId, which the foreign key on that column needs.
+        await queryInterface.addIndex("StreamPollVotes", ["pollId", "userId"], {
+            name: "poll_votes_poll_user",
+        });
+        await queryInterface.addIndex("StreamPollVotes", ["optionId"]);
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable("StreamPollVotes");
+        await queryInterface.dropTable("StreamPollOptions");
+        await queryInterface.dropTable("StreamPolls");
+    },
+};

--- a/src/lib/server/database/migrations/20260818000003-add-audio-announcements.cjs
+++ b/src/lib/server/database/migrations/20260818000003-add-audio-announcements.cjs
@@ -1,0 +1,25 @@
+"use strict";
+
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn("Audios", "isAnnouncement", {
+            allowNull: false,
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        });
+        await queryInterface.addIndex("Audios", ["isAnnouncement"], {
+            name: "audios_is_announcement",
+        });
+    },
+
+    async down(queryInterface) {
+        // Raw DDL on purpose: queryInterface.removeColumn throws
+        // "Cannot delete property 'meta' of [object Array]" with the mariadb
+        // driver this project pins. Dropping the column also drops the index
+        // that covers only it, so removeIndex is unnecessary.
+        await queryInterface.sequelize.query(
+            "ALTER TABLE `Audios` DROP COLUMN `isAnnouncement`",
+        );
+    },
+};

--- a/src/lib/server/database/models/audio.ts
+++ b/src/lib/server/database/models/audio.ts
@@ -90,6 +90,15 @@ export default class Audio extends Model {
     @Column(DataType.BOOLEAN)
     declare isFromAi: boolean;
 
+    /**
+     * Admin-only notice. Announcements are pinned to the top of the upload
+     * page so uploaders see them before submitting anything.
+     */
+    @AllowNull(false)
+    @Default(false)
+    @Column(DataType.BOOLEAN)
+    declare isAnnouncement: boolean;
+
     @ForeignKey(() => User)
     @Column(DataType.UUID)
     declare userId: string;
@@ -180,6 +189,7 @@ export default class Audio extends Model {
             favoriteCount: favoriteCount ?? 0,
             isFavorited: isFavorited,
             createdAt: this.createdAt.getTime(),
+            isAnnouncement: this.isAnnouncement,
             user: includeUser ? this.user?.toClientside() : undefined,
         };
     }

--- a/src/lib/server/database/models/comment.ts
+++ b/src/lib/server/database/models/comment.ts
@@ -36,7 +36,11 @@ import {
 } from "sequelize-typescript";
 import Audio from "./audio";
 import User from "./user";
-import type { ClientsideComment, ClientsideAudio } from "$lib/types";
+import type {
+  ClientsideComment,
+  ClientsideAudio,
+  ClientsideReaction,
+} from "$lib/types";
 
 @Table
 export default class Comment extends Model {
@@ -83,7 +87,10 @@ export default class Comment extends Model {
   public countReplies!: () => Promise<number>;
   toClientside(
     includeAudio: boolean = false,
-    includeReplies: boolean = false
+    includeReplies: boolean = false,
+    // Reactions are aggregated separately (one batched query for the whole
+    // thread) and handed in here keyed by comment id.
+    reactions?: Map<string, ClientsideReaction[]>
   ): ClientsideComment {
     return {
       id: this.id,
@@ -93,8 +100,11 @@ export default class Comment extends Model {
       user: this.user!.toClientside(),
       audio: includeAudio ? this.audio?.toClientside() : undefined,
       replies: includeReplies
-        ? this.replies?.map((r) => r.toClientside(includeAudio, includeReplies))
+        ? this.replies?.map((r) =>
+            r.toClientside(includeAudio, includeReplies, reactions)
+          )
         : undefined,
+      reactions: reactions?.get(this.id) ?? [],
     };
   }
 

--- a/src/lib/server/database/models/reaction.ts
+++ b/src/lib/server/database/models/reaction.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of the audiopub project.
  *
- * Copyright (C) 2026 the-byte-bender
+ * Copyright (C) 2024 the-byte-bender
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -26,58 +26,55 @@ import {
     Default,
     ForeignKey,
     BelongsTo,
+    Index,
+    Unique,
     CreatedAt,
     UpdatedAt,
 } from "sequelize-typescript";
 import User from "./user";
-import Stream from "./stream";
-import type { ClientsideStreamChat, ClientsideReaction } from "$lib/types";
+import { ReactionTargetType } from "$lib/types";
 
+/**
+ * A single reaction left by a user. Reactions are polymorphic: the same table
+ * backs comment reactions and stream chat reactions, discriminated by
+ * `targetType`. A user may only hold one reaction per target at a time;
+ * picking a different emoji replaces the previous one.
+ */
 @Table
-export default class StreamChat extends Model {
+export default class Reaction extends Model {
     @PrimaryKey
     @AllowNull(false)
     @Default(DataType.UUIDV4)
     @Column(DataType.UUID)
     declare id: string;
 
-    @ForeignKey(() => Stream)
-    @Column(DataType.UUID)
-    declare streamId: string;
-
-    @BelongsTo(() => Stream)
-    declare stream?: Stream;
-
+    @AllowNull(false)
+    @Unique("uniq_reaction_user_target")
     @ForeignKey(() => User)
+    @Index
     @Column(DataType.UUID)
     declare userId: string;
 
-    @BelongsTo(() => User)
+    @BelongsTo(() => User, { foreignKey: "userId", onDelete: "CASCADE" })
     declare user?: User;
 
     @AllowNull(false)
-    @Column(DataType.TEXT)
-    declare content: string;
+    @Unique("uniq_reaction_user_target")
+    @Column(DataType.STRING(32))
+    declare targetType: ReactionTargetType;
+
+    @AllowNull(false)
+    @Unique("uniq_reaction_user_target")
+    @Column(DataType.UUID)
+    declare targetId: string;
+
+    @AllowNull(false)
+    @Column(DataType.STRING(16))
+    declare emoji: string;
 
     @CreatedAt
     declare createdAt: Date;
 
     @UpdatedAt
     declare updatedAt: Date;
-
-    toClientside(
-        includeStream: boolean = false,
-        reactions: ClientsideReaction[] = [],
-    ): ClientsideStreamChat {
-        return {
-            id: this.id,
-            content: this.content,
-            createdAt: this.createdAt.getTime(),
-            user: this.user!.toClientside(),
-            stream: includeStream
-                ? this.stream?.toClientside(false)
-                : undefined,
-            reactions,
-        };
-    }
 }

--- a/src/lib/server/database/models/stream_poll.ts
+++ b/src/lib/server/database/models/stream_poll.ts
@@ -1,0 +1,138 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2024 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import {
+    Table,
+    Column,
+    Model,
+    DataType,
+    PrimaryKey,
+    AllowNull,
+    Default,
+    ForeignKey,
+    BelongsTo,
+    HasMany,
+    Index,
+    CreatedAt,
+    UpdatedAt,
+} from "sequelize-typescript";
+import User from "./user";
+import Stream from "./stream";
+import StreamPollOption from "./stream_poll_option";
+import { PollState, type ClientsidePoll } from "$lib/types";
+
+/**
+ * A poll attached to a stream. Polls outlive the broadcast: once the stream is
+ * archived, the closed poll and its final tally stay visible on the archived
+ * audio page.
+ */
+@Table
+export default class StreamPoll extends Model {
+    @PrimaryKey
+    @AllowNull(false)
+    @Default(DataType.UUIDV4)
+    @Column(DataType.UUID)
+    declare id: string;
+
+    @AllowNull(false)
+    @ForeignKey(() => Stream)
+    @Index
+    @Column(DataType.UUID)
+    declare streamId: string;
+
+    @BelongsTo(() => Stream, { foreignKey: "streamId", onDelete: "CASCADE" })
+    declare stream?: Stream;
+
+    @ForeignKey(() => User)
+    @Column(DataType.UUID)
+    declare createdById: string | null;
+
+    @BelongsTo(() => User, { foreignKey: "createdById", as: "createdBy" })
+    declare createdBy?: User | null;
+
+    @AllowNull(false)
+    @Column(DataType.TEXT)
+    declare question: string;
+
+    @AllowNull(false)
+    @Default(PollState.open)
+    @Column(DataType.STRING(16))
+    declare state: PollState;
+
+    /** Multiple choice: voters toggle any number of options. */
+    @AllowNull(false)
+    @Default(false)
+    @Column(DataType.BOOLEAN)
+    declare allowMultiple: boolean;
+
+    /** Keeps the tally secret until a viewer has voted, to curb bandwagoning. */
+    @AllowNull(false)
+    @Default(false)
+    @Column(DataType.BOOLEAN)
+    declare hideResultsUntilVote: boolean;
+
+    @Column(DataType.DATE)
+    declare closedAt: Date | null;
+
+    @HasMany(() => StreamPollOption, { onDelete: "CASCADE" })
+    declare options?: StreamPollOption[];
+
+    @CreatedAt
+    declare createdAt: Date;
+
+    @UpdatedAt
+    declare updatedAt: Date;
+
+    /**
+     * `votedOptionIds` is the viewer's own vote and must never be broadcast:
+     * each client merges its own selection into the shared tally.
+     *
+     * When `canSeeResults` is false the counts are zeroed rather than merely
+     * hidden by the UI, so a hidden tally cannot be read off the response.
+     * Callers should use the helpers in `$lib/server/polls` instead of calling
+     * this directly, since `totalVotes` counts distinct voters and has to be
+     * queried separately.
+     */
+    toClientside(
+        votedOptionIds: string[] = [],
+        voterCount: number = 0,
+        canSeeResults: boolean = true,
+    ): ClientsidePoll {
+        const options = [...(this.options ?? [])].sort(
+            (a, b) => a.position - b.position,
+        );
+        return {
+            id: this.id,
+            streamId: this.streamId,
+            question: this.question,
+            state: this.state,
+            createdAt: this.createdAt.getTime(),
+            closedAt: this.closedAt ? this.closedAt.getTime() : null,
+            allowMultiple: this.allowMultiple,
+            hideResultsUntilVote: this.hideResultsUntilVote,
+            resultsHidden: !canSeeResults,
+            totalVotes: canSeeResults ? voterCount : 0,
+            votedOptionIds,
+            options: options.map((o) => ({
+                id: o.id,
+                text: o.text,
+                votes: canSeeResults ? (o.voteCount ?? 0) : 0,
+            })),
+        };
+    }
+}

--- a/src/lib/server/database/models/stream_poll_option.ts
+++ b/src/lib/server/database/models/stream_poll_option.ts
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2024 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import {
+    Table,
+    Column,
+    Model,
+    DataType,
+    PrimaryKey,
+    AllowNull,
+    Default,
+    ForeignKey,
+    BelongsTo,
+    HasMany,
+    Index,
+    CreatedAt,
+    UpdatedAt,
+} from "sequelize-typescript";
+import StreamPoll from "./stream_poll";
+import StreamPollVote from "./stream_poll_vote";
+
+@Table
+export default class StreamPollOption extends Model {
+    @PrimaryKey
+    @AllowNull(false)
+    @Default(DataType.UUIDV4)
+    @Column(DataType.UUID)
+    declare id: string;
+
+    @AllowNull(false)
+    @ForeignKey(() => StreamPoll)
+    @Index
+    @Column(DataType.UUID)
+    declare pollId: string;
+
+    @BelongsTo(() => StreamPoll, { foreignKey: "pollId", onDelete: "CASCADE" })
+    declare poll?: StreamPoll;
+
+    @AllowNull(false)
+    @Column(DataType.STRING(200))
+    declare text: string;
+
+    @AllowNull(false)
+    @Default(0)
+    @Column(DataType.INTEGER)
+    declare position: number;
+
+    /**
+     * Denormalized tally. Votes are also stored individually so a user can
+     * change their mind, but the running count is what every listener sees.
+     */
+    @AllowNull(false)
+    @Default(0)
+    @Column(DataType.INTEGER)
+    declare voteCount: number;
+
+    @HasMany(() => StreamPollVote, { onDelete: "CASCADE" })
+    declare votes?: StreamPollVote[];
+
+    @CreatedAt
+    declare createdAt: Date;
+
+    @UpdatedAt
+    declare updatedAt: Date;
+}

--- a/src/lib/server/database/models/stream_poll_vote.ts
+++ b/src/lib/server/database/models/stream_poll_vote.ts
@@ -1,0 +1,88 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2024 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import {
+    Table,
+    Column,
+    Model,
+    DataType,
+    PrimaryKey,
+    AllowNull,
+    Default,
+    ForeignKey,
+    BelongsTo,
+    Index,
+    Unique,
+    CreatedAt,
+    UpdatedAt,
+} from "sequelize-typescript";
+import User from "./user";
+import StreamPoll from "./stream_poll";
+import StreamPollOption from "./stream_poll_option";
+
+/**
+ * One row per selected option. Single choice polls keep at most one row per
+ * user; multiple choice polls keep one per option the user picked.
+ */
+@Table
+export default class StreamPollVote extends Model {
+    @PrimaryKey
+    @AllowNull(false)
+    @Default(DataType.UUIDV4)
+    @Column(DataType.UUID)
+    declare id: string;
+
+    @AllowNull(false)
+    @Unique("uniq_poll_vote_user_option")
+    @ForeignKey(() => StreamPoll)
+    @Index
+    @Column(DataType.UUID)
+    declare pollId: string;
+
+    @BelongsTo(() => StreamPoll, { foreignKey: "pollId", onDelete: "CASCADE" })
+    declare poll?: StreamPoll;
+
+    @AllowNull(false)
+    @Unique("uniq_poll_vote_user_option")
+    @ForeignKey(() => StreamPollOption)
+    @Index
+    @Column(DataType.UUID)
+    declare optionId: string;
+
+    @BelongsTo(() => StreamPollOption, {
+        foreignKey: "optionId",
+        onDelete: "CASCADE",
+    })
+    declare option?: StreamPollOption;
+
+    @AllowNull(false)
+    @Unique("uniq_poll_vote_user_option")
+    @ForeignKey(() => User)
+    @Index
+    @Column(DataType.UUID)
+    declare userId: string;
+
+    @BelongsTo(() => User, { foreignKey: "userId", onDelete: "CASCADE" })
+    declare user?: User;
+
+    @CreatedAt
+    declare createdAt: Date;
+
+    @UpdatedAt
+    declare updatedAt: Date;
+}

--- a/src/lib/server/polls.ts
+++ b/src/lib/server/polls.ts
@@ -1,0 +1,311 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2024 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import database, {
+    StreamPoll,
+    StreamPollOption,
+    StreamPollVote,
+} from "$lib/server/database";
+import { Op } from "sequelize";
+import { PollState, type ClientsidePoll } from "$lib/types";
+
+export const MAX_POLL_OPTIONS = 6;
+export const MIN_POLL_OPTIONS = 2;
+export const MAX_POLL_QUESTION_LENGTH = 300;
+export const MAX_POLL_OPTION_LENGTH = 200;
+/** Guards against a stream page turning into an endless wall of polls. */
+export const MAX_OPEN_POLLS_PER_STREAM = 3;
+
+export class PollValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "PollValidationError";
+    }
+}
+
+export interface CreatePollInput {
+    question: string;
+    options: string[];
+    allowMultiple?: boolean;
+    hideResultsUntilVote?: boolean;
+}
+
+const pollInclude = [{ model: StreamPollOption, as: "options" }];
+
+async function reload(pollId: string): Promise<StreamPoll> {
+    const poll = await StreamPoll.findByPk(pollId, { include: pollInclude });
+    if (!poll) {
+        throw new PollValidationError("Poll not found");
+    }
+    return poll;
+}
+
+/** Distinct voters, which is the denominator the percentages use. */
+async function countVoters(pollId: string): Promise<number> {
+    return StreamPollVote.count({
+        where: { pollId },
+        distinct: true,
+        col: "userId",
+    });
+}
+
+async function votedOptionIds(
+    pollId: string,
+    userId: string | null | undefined,
+): Promise<string[]> {
+    if (!userId) return [];
+    const rows = await StreamPollVote.findAll({
+        where: { pollId, userId },
+        attributes: ["optionId"],
+        raw: true,
+    });
+    return (rows as unknown as { optionId: string }[]).map((r) => r.optionId);
+}
+
+/**
+ * A hidden tally opens up once the poll closes, and is always visible to the
+ * host and to anyone who has already voted.
+ */
+function canSeeResults(
+    poll: StreamPoll,
+    hasVoted: boolean,
+    isHost: boolean,
+): boolean {
+    if (!poll.hideResultsUntilVote) return true;
+    if (poll.state === PollState.closed) return true;
+    return hasVoted || isHost;
+}
+
+/** Serializes a poll from one viewer's point of view. */
+export async function serializePoll(
+    poll: StreamPoll,
+    viewerId: string | null | undefined,
+    isHost: boolean = false,
+): Promise<ClientsidePoll> {
+    const [mine, voters] = await Promise.all([
+        votedOptionIds(poll.id, viewerId),
+        countVoters(poll.id),
+    ]);
+    return poll.toClientside(
+        mine,
+        voters,
+        canSeeResults(poll, mine.length > 0, isHost),
+    );
+}
+
+/**
+ * Serializes a poll for the SSE broadcast, which every listener receives.
+ * It carries no viewer specific state, and withholds the tally of a
+ * hidden-results poll from everyone: viewers entitled to see it refresh
+ * through their own request instead.
+ */
+export async function serializePollForBroadcast(
+    poll: StreamPoll,
+): Promise<ClientsidePoll> {
+    const voters = await countVoters(poll.id);
+    return poll.toClientside(
+        [],
+        voters,
+        canSeeResults(poll, false, false),
+    );
+}
+
+export async function createPoll(
+    streamId: string,
+    createdById: string,
+    input: CreatePollInput,
+): Promise<StreamPoll> {
+    const trimmedQuestion = (input.question ?? "").trim();
+    if (
+        trimmedQuestion.length < 3 ||
+        trimmedQuestion.length > MAX_POLL_QUESTION_LENGTH
+    ) {
+        throw new PollValidationError(
+            `The question must be between 3 and ${MAX_POLL_QUESTION_LENGTH} characters`,
+        );
+    }
+
+    const options = (Array.isArray(input.options) ? input.options : [])
+        .map((text) => (typeof text === "string" ? text.trim() : ""))
+        .filter((text) => text.length > 0);
+
+    if (options.length < MIN_POLL_OPTIONS || options.length > MAX_POLL_OPTIONS) {
+        throw new PollValidationError(
+            `A poll needs between ${MIN_POLL_OPTIONS} and ${MAX_POLL_OPTIONS} options`,
+        );
+    }
+    if (options.some((text) => text.length > MAX_POLL_OPTION_LENGTH)) {
+        throw new PollValidationError(
+            `Each option must be at most ${MAX_POLL_OPTION_LENGTH} characters`,
+        );
+    }
+
+    const openPolls = await StreamPoll.count({
+        where: { streamId, state: PollState.open },
+    });
+    if (openPolls >= MAX_OPEN_POLLS_PER_STREAM) {
+        throw new PollValidationError(
+            `You already have ${MAX_OPEN_POLLS_PER_STREAM} open polls. Close one first.`,
+        );
+    }
+
+    const pollId = await database.transaction(async (transaction) => {
+        const poll = await StreamPoll.create(
+            {
+                streamId,
+                createdById,
+                question: trimmedQuestion,
+                state: PollState.open,
+                allowMultiple: Boolean(input.allowMultiple),
+                hideResultsUntilVote: Boolean(input.hideResultsUntilVote),
+            },
+            { transaction },
+        );
+        await StreamPollOption.bulkCreate(
+            options.map((text, index) => ({
+                pollId: poll.id,
+                text,
+                position: index,
+                voteCount: 0,
+            })),
+            { transaction },
+        );
+        return poll.id;
+    });
+
+    return reload(pollId);
+}
+
+export async function closePoll(poll: StreamPoll): Promise<StreamPoll> {
+    if (poll.state !== PollState.closed) {
+        poll.state = PollState.closed;
+        poll.closedAt = new Date();
+        await poll.save();
+    }
+    return reload(poll.id);
+}
+
+/**
+ * Records a vote. Single choice polls move the user's vote to the given
+ * option; multiple choice polls toggle it. Returns the refreshed poll, or
+ * null when nothing changed (re-picking the only option already selected in a
+ * single choice poll).
+ */
+export async function castVote(
+    poll: StreamPoll,
+    userId: string,
+    optionId: string,
+): Promise<StreamPoll | null> {
+    if (poll.state !== PollState.open) {
+        throw new PollValidationError("This poll is closed");
+    }
+
+    const option = await StreamPollOption.findOne({
+        where: { id: optionId, pollId: poll.id },
+    });
+    if (!option) {
+        throw new PollValidationError("Unknown option");
+    }
+
+    const changed = await database.transaction(async (transaction) => {
+        const existing = await StreamPollVote.findAll({
+            where: { pollId: poll.id, userId },
+            transaction,
+            lock: transaction.LOCK.UPDATE,
+        });
+
+        if (poll.allowMultiple) {
+            const already = existing.find((v) => v.optionId === optionId);
+            if (already) {
+                await already.destroy({ transaction });
+                await StreamPollOption.decrement("voteCount", {
+                    by: 1,
+                    where: { id: optionId, voteCount: { [Op.gt]: 0 } },
+                    transaction,
+                });
+                return true;
+            }
+            await StreamPollVote.create(
+                { pollId: poll.id, optionId, userId },
+                { transaction },
+            );
+            await StreamPollOption.increment("voteCount", {
+                by: 1,
+                where: { id: optionId },
+                transaction,
+            });
+            return true;
+        }
+
+        const current = existing[0];
+        if (current && current.optionId === optionId) {
+            return false;
+        }
+
+        if (current) {
+            await StreamPollOption.decrement("voteCount", {
+                by: 1,
+                where: { id: current.optionId, voteCount: { [Op.gt]: 0 } },
+                transaction,
+            });
+            current.optionId = optionId;
+            await current.save({ transaction });
+        } else {
+            await StreamPollVote.create(
+                { pollId: poll.id, optionId, userId },
+                { transaction },
+            );
+        }
+
+        await StreamPollOption.increment("voteCount", {
+            by: 1,
+            where: { id: optionId },
+            transaction,
+        });
+        return true;
+    });
+
+    return changed ? reload(poll.id) : null;
+}
+
+export async function getPollsForStream(
+    streamId: string,
+    viewerId?: string | null,
+    isHost: boolean = false,
+): Promise<ClientsidePoll[]> {
+    const polls = await StreamPoll.findAll({
+        where: { streamId },
+        include: pollInclude,
+        order: [["createdAt", "DESC"]],
+    });
+
+    return Promise.all(
+        polls.map((poll) => serializePoll(poll, viewerId, isHost)),
+    );
+}
+
+export async function findPoll(
+    pollId: string,
+    streamId: string,
+): Promise<StreamPoll | null> {
+    const poll = await StreamPoll.findByPk(pollId, { include: pollInclude });
+    if (!poll || poll.streamId !== streamId) {
+        return null;
+    }
+    return poll;
+}

--- a/src/lib/server/reactions.ts
+++ b/src/lib/server/reactions.ts
@@ -1,0 +1,138 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2024 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Reaction } from "$lib/server/database";
+import { Op } from "sequelize";
+import { isValidReactionEmoji } from "$lib/reactions";
+import { ReactionTargetType, type ClientsideReaction } from "$lib/types";
+
+export class InvalidReactionError extends Error {
+    constructor() {
+        super("Unknown reaction");
+        this.name = "InvalidReactionError";
+    }
+}
+
+/**
+ * Applies a user's reaction to a target.
+ *
+ * Passing the emoji the user already reacted with removes the reaction, which
+ * is what makes each reaction button a toggle. Passing a different emoji
+ * replaces the previous one, since a user holds at most one reaction per
+ * target. Returns the fresh summary from that user's point of view.
+ */
+export async function toggleReaction(
+    userId: string,
+    targetType: ReactionTargetType,
+    targetId: string,
+    emoji: string,
+): Promise<ClientsideReaction[]> {
+    if (!isValidReactionEmoji(emoji)) {
+        throw new InvalidReactionError();
+    }
+
+    const existing = await Reaction.findOne({
+        where: { userId, targetType, targetId },
+    });
+
+    if (existing && existing.emoji === emoji) {
+        await existing.destroy();
+    } else if (existing) {
+        existing.emoji = emoji;
+        await existing.save();
+    } else {
+        try {
+            await Reaction.create({ userId, targetType, targetId, emoji });
+        } catch (error) {
+            // Two rapid clicks can race on the unique index; the first one won,
+            // and that is a perfectly good outcome.
+            if ((error as any)?.name !== "SequelizeUniqueConstraintError") {
+                throw error;
+            }
+        }
+    }
+
+    const summaries = await summarizeReactions(targetType, [targetId], userId);
+    return summaries.get(targetId) ?? [];
+}
+
+/**
+ * Aggregates reactions for a batch of targets in a single query, so a page
+ * full of comments does not turn into one query per comment.
+ */
+export async function summarizeReactions(
+    targetType: ReactionTargetType,
+    targetIds: string[],
+    viewerId?: string | null,
+): Promise<Map<string, ClientsideReaction[]>> {
+    const result = new Map<string, ClientsideReaction[]>();
+    if (targetIds.length === 0) {
+        return result;
+    }
+
+    const rows = await Reaction.findAll({
+        where: { targetType, targetId: { [Op.in]: targetIds } },
+        attributes: ["targetId", "emoji", "userId"],
+        raw: true,
+    });
+
+    const counts = new Map<string, Map<string, number>>();
+    const mine = new Map<string, string>();
+
+    for (const row of rows as unknown as {
+        targetId: string;
+        emoji: string;
+        userId: string;
+    }[]) {
+        let perTarget = counts.get(row.targetId);
+        if (!perTarget) {
+            perTarget = new Map<string, number>();
+            counts.set(row.targetId, perTarget);
+        }
+        perTarget.set(row.emoji, (perTarget.get(row.emoji) ?? 0) + 1);
+        if (viewerId && row.userId === viewerId) {
+            mine.set(row.targetId, row.emoji);
+        }
+    }
+
+    for (const [targetId, perTarget] of counts) {
+        const summary: ClientsideReaction[] = [...perTarget.entries()]
+            .map(([emoji, count]) => ({
+                emoji,
+                count,
+                reacted: mine.get(targetId) === emoji,
+            }))
+            // Most reacted first, then alphabetically so the order is stable
+            // between renders.
+            .sort((a, b) => b.count - a.count || a.emoji.localeCompare(b.emoji));
+        result.set(targetId, summary);
+    }
+
+    return result;
+}
+
+/**
+ * Drops reactions whose target no longer exists. Reactions are polymorphic and
+ * therefore have no foreign key to cascade from.
+ */
+export async function deleteReactionsFor(
+    targetType: ReactionTargetType,
+    targetId: string,
+): Promise<void> {
+    await Reaction.destroy({ where: { targetType, targetId } });
+}

--- a/src/lib/server/streaming.ts
+++ b/src/lib/server/streaming.ts
@@ -24,7 +24,11 @@ import { EventEmitter } from "node:events";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import type { ClientsideStreamChat, ClientsideStreamMute } from "$lib/types";
+import type {
+    ClientsideStreamChat,
+    ClientsideStreamMute,
+    ClientsideReaction,
+} from "$lib/types";
 import { StreamState, StreamFormat } from "$lib/types";
 
 const execFileAsync = promisify(execFile);
@@ -57,6 +61,27 @@ export class StreamingService extends EventEmitter {
             streamId,
             chatId,
         } as StreamChatDeletedEvent);
+    }
+
+    /**
+     * Reaction tallies are shared by everyone, but "did I react" is not, so the
+     * broadcast carries the actor and their new emoji and each client folds its
+     * own state in.
+     */
+    notifyChatReaction(
+        streamId: string,
+        chatId: string,
+        reactions: ClientsideReaction[],
+        actorId: string,
+        emoji: string | null,
+    ) {
+        this.emit(STREAM_CHAT_REACTION, {
+            streamId,
+            chatId,
+            reactions,
+            actorId,
+            emoji,
+        } as StreamChatReactionEvent);
     }
 
     notifyStateChanged(
@@ -574,6 +599,7 @@ export const STREAM_ARCHIVED = "stream:archived";
 export const STREAM_DESTROYED = "stream:destroyed";
 export const STREAM_LISTENERS_CHANGED = "stream:listeners_changed";
 export const STREAM_MODERATION_CHANGED = "stream:moderation_changed";
+export const STREAM_CHAT_REACTION = "stream:chat_reaction";
 
 export interface StreamEvent {
     streamId: string;
@@ -590,6 +616,15 @@ export interface StreamChatSentEvent extends StreamEvent {
 
 export interface StreamChatDeletedEvent extends StreamEvent {
     chatId: string;
+}
+
+export interface StreamChatReactionEvent extends StreamEvent {
+    chatId: string;
+    /** Shared tally; the `reacted` flags in it are meaningless to other viewers. */
+    reactions: ClientsideReaction[];
+    actorId: string;
+    /** The actor's reaction after the change, or null when they removed it. */
+    emoji: string | null;
 }
 
 export interface StreamListenersChangedEvent extends StreamEvent {

--- a/src/lib/server/streaming.ts
+++ b/src/lib/server/streaming.ts
@@ -27,6 +27,7 @@ import os from "node:os";
 import type {
     ClientsideStreamChat,
     ClientsideStreamMute,
+    ClientsidePoll,
     ClientsideReaction,
 } from "$lib/types";
 import { StreamState, StreamFormat } from "$lib/types";
@@ -82,6 +83,25 @@ export class StreamingService extends EventEmitter {
             actorId,
             emoji,
         } as StreamChatReactionEvent);
+    }
+
+    notifyPollChanged(
+        streamId: string,
+        kind: "created" | "updated" | "closed",
+        poll: ClientsidePoll,
+    ) {
+        this.emit(STREAM_POLL_CHANGED, {
+            streamId,
+            kind,
+            poll,
+        } as StreamPollChangedEvent);
+    }
+
+    notifyPollDeleted(streamId: string, pollId: string) {
+        this.emit(STREAM_POLL_DELETED, {
+            streamId,
+            pollId,
+        } as StreamPollDeletedEvent);
     }
 
     notifyStateChanged(
@@ -600,6 +620,8 @@ export const STREAM_DESTROYED = "stream:destroyed";
 export const STREAM_LISTENERS_CHANGED = "stream:listeners_changed";
 export const STREAM_MODERATION_CHANGED = "stream:moderation_changed";
 export const STREAM_CHAT_REACTION = "stream:chat_reaction";
+export const STREAM_POLL_CHANGED = "stream:poll_changed";
+export const STREAM_POLL_DELETED = "stream:poll_deleted";
 
 export interface StreamEvent {
     streamId: string;
@@ -625,6 +647,15 @@ export interface StreamChatReactionEvent extends StreamEvent {
     actorId: string;
     /** The actor's reaction after the change, or null when they removed it. */
     emoji: string | null;
+}
+
+export interface StreamPollChangedEvent extends StreamEvent {
+    kind: "created" | "updated" | "closed";
+    poll: ClientsidePoll;
+}
+
+export interface StreamPollDeletedEvent extends StreamEvent {
+    pollId: string;
 }
 
 export interface StreamListenersChangedEvent extends StreamEvent {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,41 @@ export interface ClientsideReaction {
     reacted: boolean;
 }
 
+export enum PollState {
+    open = "open",
+    closed = "closed",
+}
+
+export interface ClientsidePollOption {
+    id: string;
+    text: string;
+    votes: number;
+}
+
+export interface ClientsidePoll {
+    id: string;
+    streamId: string;
+    question: string;
+    state: PollState;
+    createdAt: number;
+    closedAt: number | null;
+    /** When true, voters may pick several options instead of just one. */
+    allowMultiple: boolean;
+    /** When true, the tally stays hidden until the viewer has voted. */
+    hideResultsUntilVote: boolean;
+    /**
+     * True when the counts in this payload were withheld from the viewer.
+     * Vote numbers are zeroed in that case rather than merely hidden by the
+     * UI, so the answer cannot be read off the network response.
+     */
+    resultsHidden: boolean;
+    /** Distinct voters, which is what the percentages are relative to. */
+    totalVotes: number;
+    /** The viewer's own votes; never included in broadcast payloads. */
+    votedOptionIds: string[];
+    options: ClientsidePollOption[];
+}
+
 export interface ClientsideStream {
     id: string;
     title: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,6 +70,8 @@ export interface ClientsideAudio {
     favoriteCount: number;
     isFavorited?: boolean;
     createdAt: number;
+    /** Admin-authored notice pinned to the top of the upload page. */
+    isAnnouncement: boolean;
     user?: ClientsideUser;
     comments?: ClientsideComment[];
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,19 @@ export interface ClientsideUser {
     isTrusted: boolean;
 }
 
+export enum ReactionTargetType {
+    comment = "comment",
+    streamChat = "stream_chat",
+}
+
+/** Aggregated reactions for one target, from the point of view of a viewer. */
+export interface ClientsideReaction {
+    emoji: string;
+    count: number;
+    /** True when the requesting user is one of the reactors. */
+    reacted: boolean;
+}
+
 export interface ClientsideStream {
     id: string;
     title: string;
@@ -45,6 +58,7 @@ export interface ClientsideStreamChat {
     createdAt: number;
     user: ClientsideUser;
     stream?: ClientsideStream;
+    reactions?: ClientsideReaction[];
 }
 
 export interface ClientsideStreamMute {
@@ -84,6 +98,7 @@ export interface ClientsideComment {
     user: ClientsideUser;
     audio?: ClientsideAudio;
     replies?: ClientsideComment[];
+    reactions?: ClientsideReaction[];
 }
 
 export enum NotificationType {

--- a/src/routes/listen/[id]/+page.server.ts
+++ b/src/routes/listen/[id]/+page.server.ts
@@ -47,6 +47,7 @@ import {
     summarizeReactions,
     toggleReaction,
 } from "$lib/server/reactions";
+import { getPollsForStream } from "$lib/server/polls";
 import { ReactionTargetType } from "$lib/types";
 
 export const load: PageServerLoad = async (event) => {
@@ -220,6 +221,10 @@ export const load: PageServerLoad = async (event) => {
                   );
               })
             : null,
+        // Polls from the broadcast stay readable once it is archived.
+        archivedPolls: audio.archivedStreamId
+            ? await getPollsForStream(audio.archivedStreamId, viewer?.id)
+            : [],
         isSubscribed,
         canEdit,
         hasEdits: Boolean(viewer?.isAdmin && edits.length > 0),
@@ -365,7 +370,7 @@ export const actions: Actions = {
             return error(404, "Not found");
         }
         const form = await event.request.formData();
-        // The button posts the state it wants, so the action stays idempotent
+        // The toggle posts the state it wants, so the action stays idempotent
         // and a double submit cannot flip it back.
         audio.isAnnouncement = form.get("isAnnouncement") === "on";
         await audio.save();

--- a/src/routes/listen/[id]/+page.server.ts
+++ b/src/routes/listen/[id]/+page.server.ts
@@ -41,6 +41,13 @@ import {
     MAX_USER_AUDIO_EDITS,
     updateAudioDetails,
 } from "$lib/server/audio_edits";
+import {
+    InvalidReactionError,
+    deleteReactionsFor,
+    summarizeReactions,
+    toggleReaction,
+} from "$lib/server/reactions";
+import { ReactionTargetType } from "$lib/types";
 
 export const load: PageServerLoad = async (event) => {
     const audio = await Audio.findByPk(event.params.id, {
@@ -102,6 +109,12 @@ export const load: PageServerLoad = async (event) => {
             { where: whereClause },
         );
     }
+
+    const commentReactions = await summarizeReactions(
+        ReactionTargetType.comment,
+        comments.map((c) => c.id),
+        viewer?.id,
+    );
 
     const sortedComments = Comment.constructThreads(comments);
     const canEdit = Boolean(
@@ -185,7 +198,9 @@ export const load: PageServerLoad = async (event) => {
 
     return {
         audio: audio.toClientside(true, favoriteCount, isFavorited),
-        comments: sortedComments.map((c) => c.toClientside(false, true)),
+        comments: sortedComments.map((c) =>
+            c.toClientside(false, true, commentReactions),
+        ),
         mimeType: audio.mimeType,
         isFollowing,
         archivedStreamId: audio.archivedStreamId,
@@ -194,7 +209,16 @@ export const load: PageServerLoad = async (event) => {
                   where: { streamId: audio.archivedStreamId },
                   include: { model: User },
                   order: [["createdAt", "ASC"]],
-              }).then((chats) => chats.map((c) => c.toClientside()))
+              }).then(async (chats) => {
+                  const reactions = await summarizeReactions(
+                      ReactionTargetType.streamChat,
+                      chats.map((c) => c.id),
+                      viewer?.id,
+                  );
+                  return chats.map((c) =>
+                      c.toClientside(false, reactions.get(c.id) ?? []),
+                  );
+              })
             : null,
         isSubscribed,
         canEdit,
@@ -296,6 +320,40 @@ export const actions: Actions = {
         }
 
         return { editSuccess: true };
+    },
+    react_comment: async (event) => {
+        const user = event.locals.user;
+        if (!user || !user.isVerified || user.isBanned) {
+            return error(403, "Forbidden");
+        }
+
+        const form = await event.request.formData();
+        const targetId = form.get("targetId");
+        const emoji = form.get("emoji");
+        if (typeof targetId !== "string" || typeof emoji !== "string") {
+            return fail(400, { reactionMessage: "Invalid reaction" });
+        }
+
+        const comment = await Comment.findByPk(targetId);
+        if (!comment || comment.audioId !== event.params.id) {
+            return error(404, "Not found");
+        }
+
+        try {
+            await toggleReaction(
+                user.id,
+                ReactionTargetType.comment,
+                comment.id,
+                emoji,
+            );
+        } catch (err) {
+            if (err instanceof InvalidReactionError) {
+                return fail(400, { reactionMessage: "Unknown reaction" });
+            }
+            throw err;
+        }
+
+        return { success: true };
     },
     setAnnouncement: async (event) => {
         const user = event.locals.user;
@@ -425,6 +483,7 @@ export const actions: Actions = {
 
         // Otherwise we can just delete it
         await comment.destroy();
+        await deleteReactionsFor(ReactionTargetType.comment, comment.id);
         return { success: true };
     },
     follow: async (event) => {

--- a/src/routes/listen/[id]/+page.server.ts
+++ b/src/routes/listen/[id]/+page.server.ts
@@ -297,6 +297,22 @@ export const actions: Actions = {
 
         return { editSuccess: true };
     },
+    setAnnouncement: async (event) => {
+        const user = event.locals.user;
+        if (!user || !user.isAdmin) {
+            return error(403, "Forbidden");
+        }
+        const audio = await Audio.findByPk(event.params.id);
+        if (!audio) {
+            return error(404, "Not found");
+        }
+        const form = await event.request.formData();
+        // The button posts the state it wants, so the action stays idempotent
+        // and a double submit cannot flip it back.
+        audio.isAnnouncement = form.get("isAnnouncement") === "on";
+        await audio.save();
+        return { announcementSuccess: true };
+    },
     delete: async (event) => {
         const user = event.locals.user;
         const audio = await Audio.findByPk(event.params.id, { include: User });

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -161,8 +161,17 @@
 
 <h1>
     {data.audio.title}
+    {#if data.audio.isAnnouncement}<span class="announcement-tag"
+            >[announcement]</span
+        >{/if}
     {#if data.hasEdits}<span class="edited-tag">[edited]</span>{/if}
 </h1>
+
+{#if data.audio.isAnnouncement}
+    <p class="announcement-note" role="note">
+        This audio is pinned to the top of the upload page as an announcement.
+    </p>
+{/if}
 
 <div class="audio-player">
     <AudioPlayer
@@ -389,6 +398,25 @@
                 >
             </Modal>
         {/if}
+    {/if}
+
+    {#if data.isAdmin}
+        <form use:enhance action="?/setAnnouncement" method="POST">
+            <!-- A plain button that states the action it performs, rather
+                 than a checkbox the admin has to remember to save. -->
+            <input
+                type="hidden"
+                name="isAnnouncement"
+                value={data.audio.isAnnouncement ? "off" : "on"}
+            />
+            <button type="submit">
+                {#if data.audio.isAnnouncement}
+                    Unpin as announcement
+                {:else}
+                    Pin as announcement on the upload page
+                {/if}
+            </button>
+        </form>
     {/if}
 
     {#if data.user && (data.isAdmin || data.user.id === data.audio.user?.id)}
@@ -671,6 +699,22 @@
     .edited-tag {
         font-size: 0.65em;
         font-weight: normal;
+    }
+
+    .announcement-tag {
+        font-size: 0.65em;
+        font-weight: normal;
+        color: #856404;
+    }
+
+    .announcement-note {
+        margin: 0 auto 1rem;
+        max-width: 700px;
+        padding: 0.5rem 0.75rem;
+        background: #fff3cd;
+        border: 1px solid #ffeeba;
+        border-radius: 4px;
+        color: #856404;
     }
 
     .edit-form {

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -25,7 +25,11 @@
     import StreamChatList from "$lib/components/stream_chat_list.svelte";
     import title from "$lib/title";
     import SafeMarkdown from "$lib/components/safe_markdown.svelte";
-    import type { ClientsideComment } from "$lib/types.js";
+    import type {
+        ClientsideComment,
+        ClientsideStreamChat,
+    } from "$lib/types.js";
+    import { invalidateAll } from "$app/navigation";
     import SubscribeButton from "$lib/components/subscribe_button.svelte";
     import AudioPlayer from "$lib/components/audio_player.svelte";
     import Modal from "$lib/components/modal.svelte";
@@ -135,6 +139,24 @@
     let commentField: HTMLTextAreaElement;
     function onReply(comment: ClientsideComment) {
         commentField.focus();
+    }
+
+    async function onArchivedChatReact(
+        chat: ClientsideStreamChat,
+        emoji: string,
+    ) {
+        const res = await fetch(
+            `/live/${data.archivedStreamId}/${chat.id}`,
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ emoji }),
+            },
+        );
+        if (res.ok) {
+            // The archived page has no live connection, so reload the tally.
+            await invalidateAll();
+        }
     }
 
     function onShareClick() {
@@ -448,6 +470,7 @@
                 user={data.user ?? undefined}
                 isAdmin={data.isAdmin}
                 streamOwnerId={data.audio.user?.id ?? null}
+                onReact={onArchivedChatReact}
                 onDelete={async (chatId) => {
                     await fetch(`/live/${data.archivedStreamId}/${chatId}`, {
                         method: "DELETE",

--- a/src/routes/listen/[id]/+page.svelte
+++ b/src/routes/listen/[id]/+page.svelte
@@ -23,6 +23,7 @@
     import { onMount } from "svelte";
     import CommentList from "$lib/components/comment_list.svelte";
     import StreamChatList from "$lib/components/stream_chat_list.svelte";
+    import StreamPolls from "$lib/components/stream_polls.svelte";
     import title from "$lib/title";
     import SafeMarkdown from "$lib/components/safe_markdown.svelte";
     import type {
@@ -478,6 +479,15 @@
                 }}
             />
         </details>
+    {/if}
+
+    {#if data.archivedStreamId && data.archivedPolls && data.archivedPolls.length > 0}
+        <StreamPolls
+            streamId={data.archivedStreamId}
+            polls={data.archivedPolls}
+            readOnly
+            heading="Poll results from this stream"
+        />
     {/if}
 
     <section role="group" aria-label="Comments">

--- a/src/routes/live/[id]/+page.server.ts
+++ b/src/routes/live/[id]/+page.server.ts
@@ -28,6 +28,7 @@ import type { PageServerLoad } from "./$types";
 import { Op } from "sequelize";
 import { ReactionTargetType, type ClientsideStreamMute } from "$lib/types";
 import { summarizeReactions } from "$lib/server/reactions";
+import { getPollsForStream } from "$lib/server/polls";
 
 export const load: PageServerLoad = async (event) => {
     const stream = await Stream.findByPk(event.params.id, {
@@ -88,5 +89,10 @@ export const load: PageServerLoad = async (event) => {
         ),
         mutes,
         slowModeSeconds: stream.slowModeSeconds,
+        polls: await getPollsForStream(
+            stream.id,
+            viewer?.id,
+            Boolean(canModerate),
+        ),
     };
 };

--- a/src/routes/live/[id]/+page.server.ts
+++ b/src/routes/live/[id]/+page.server.ts
@@ -26,7 +26,8 @@ import {
 import { error, redirect } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 import { Op } from "sequelize";
-import type { ClientsideStreamMute } from "$lib/types";
+import { ReactionTargetType, type ClientsideStreamMute } from "$lib/types";
+import { summarizeReactions } from "$lib/server/reactions";
 
 export const load: PageServerLoad = async (event) => {
     const stream = await Stream.findByPk(event.params.id, {
@@ -73,9 +74,18 @@ export const load: PageServerLoad = async (event) => {
         }));
     }
 
+    const chats = stream.streamChats ?? [];
+    const chatReactions = await summarizeReactions(
+        ReactionTargetType.streamChat,
+        chats.map((c) => c.id),
+        viewer?.id,
+    );
+
     return {
         stream: stream.toClientside(true),
-        chats: stream.streamChats?.map((c) => c.toClientside()),
+        chats: chats.map((c) =>
+            c.toClientside(false, chatReactions.get(c.id) ?? []),
+        ),
         mutes,
         slowModeSeconds: stream.slowModeSeconds,
     };

--- a/src/routes/live/[id]/+page.svelte
+++ b/src/routes/live/[id]/+page.svelte
@@ -31,6 +31,7 @@
     import type {
         ClientsideStreamChat,
         ClientsideStreamMute,
+        ClientsideReaction,
     } from "$lib/types";
 
     onMount(() => title.set(data.stream.title));
@@ -75,6 +76,36 @@
         }, durationMs);
     }
 
+    async function handleChatReaction(
+        chat: ClientsideStreamChat,
+        emoji: string,
+    ) {
+        try {
+            const res = await fetch(`/live/${data.stream.id}/${chat.id}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ emoji }),
+            });
+            if (!res.ok) {
+                setChatNotice("Could not save your reaction.");
+                return;
+            }
+            const body = await res.json();
+            applyChatReactions(chat.id, body.reactions as ClientsideReaction[]);
+        } catch {
+            setChatNotice("Could not save your reaction.");
+        }
+    }
+
+    function applyChatReactions(
+        chatId: string,
+        reactions: ClientsideReaction[],
+    ) {
+        chats = chats.map((c) =>
+            c.id === chatId ? { ...c, reactions } : c,
+        );
+    }
+
     function connectSSE() {
         eventSource = new EventSource(`/live/${data.stream.id}/events`);
 
@@ -104,6 +135,23 @@
             const chat = JSON.parse(e.data) as ClientsideStreamChat;
             chats = [...chats.filter((c) => c.id !== chat.id), chat];
             handleNewChat(chat);
+        });
+
+        eventSource.addEventListener("chat_reaction", (e) => {
+            const d = JSON.parse(e.data);
+            const reactions = (d.reactions ?? []) as ClientsideReaction[];
+            // The broadcast tally has no notion of "mine"; recompute it from
+            // the actor when it was us, and keep our previous flags otherwise.
+            const mine =
+                d.actorId === data.user?.id
+                    ? (d.emoji as string | null)
+                    : (chats
+                          .find((c) => c.id === d.chatId)
+                          ?.reactions?.find((r) => r.reacted)?.emoji ?? null);
+            applyChatReactions(
+                d.chatId,
+                reactions.map((r) => ({ ...r, reacted: r.emoji === mine })),
+            );
         });
 
         eventSource.addEventListener("chat_delete", (e) => {
@@ -413,6 +461,7 @@
     isAdmin={data.isAdmin}
     onDelete={handleDeleteChat}
     onMute={handleMute}
+    onReact={handleChatReaction}
     streamOwnerId={data.stream.user?.id ?? null}
     onSendMessage={handleSendMessage}
     notice={chatNotice}

--- a/src/routes/live/[id]/+page.svelte
+++ b/src/routes/live/[id]/+page.svelte
@@ -21,6 +21,7 @@
 
     import { onMount, tick } from "svelte";
     import StreamChatList from "$lib/components/stream_chat_list.svelte";
+    import StreamPolls from "$lib/components/stream_polls.svelte";
     import AudioPlayer from "$lib/components/audio_player.svelte";
     import ChatReader from "$lib/components/chat_reader.svelte";
     import SafeMarkdown from "$lib/components/safe_markdown.svelte";
@@ -31,6 +32,7 @@
     import type {
         ClientsideStreamChat,
         ClientsideStreamMute,
+        ClientsidePoll,
         ClientsideReaction,
     } from "$lib/types";
 
@@ -57,6 +59,7 @@
     let latestChat: ClientsideStreamChat | null = null;
     let eventSource: EventSource | null = null;
 
+    let polls = (data.polls ?? []) as ClientsidePoll[];
     let mutes = (data.mutes ?? []) as ClientsideStreamMute[];
     let slowModeSeconds = data.slowModeSeconds ?? 0;
     let slowModeValue = String(slowModeSeconds);
@@ -74,6 +77,44 @@
             chatNotice = "";
             noticeTimer = null;
         }, durationMs);
+    }
+
+    /**
+     * Broadcast polls carry no `votedOptionIds` (they are per viewer), so keep
+     * the ones we already know unless the update came from our own request.
+     */
+    function mergePoll(incoming: ClientsidePoll, fromBroadcast: boolean) {
+        const existing = polls.find((p) => p.id === incoming.id);
+        const merged = fromBroadcast
+            ? {
+                  ...incoming,
+                  votedOptionIds:
+                      existing?.votedOptionIds ?? incoming.votedOptionIds,
+              }
+            : incoming;
+        polls = existing
+            ? polls.map((p) => (p.id === merged.id ? merged : p))
+            : [merged, ...polls];
+    }
+
+    /**
+     * A hidden-results poll is broadcast with its tally stripped, so a viewer
+     * who is entitled to see it (they voted, or they host the stream) has to
+     * ask for their own view of it.
+     */
+    async function refreshPolls() {
+        try {
+            const res = await fetch(`/live/${data.stream.id}/polls`);
+            if (!res.ok) return;
+            const body = await res.json();
+            polls = body.polls as ClientsidePoll[];
+        } catch {
+            // The next broadcast will try again.
+        }
+    }
+
+    function removePoll(pollId: string) {
+        polls = polls.filter((p) => p.id !== pollId);
     }
 
     async function handleChatReaction(
@@ -152,6 +193,24 @@
                 d.chatId,
                 reactions.map((r) => ({ ...r, reacted: r.emoji === mine })),
             );
+        });
+
+        eventSource.addEventListener("poll", (e) => {
+            const d = JSON.parse(e.data);
+            const incoming = d.poll as ClientsidePoll;
+            const existing = polls.find((p) => p.id === incoming.id);
+            mergePoll(incoming, true);
+            if (
+                incoming.resultsHidden &&
+                (isOwnerOrAdmin || (existing?.votedOptionIds.length ?? 0) > 0)
+            ) {
+                refreshPolls();
+            }
+        });
+
+        eventSource.addEventListener("poll_delete", (e) => {
+            const { pollId } = JSON.parse(e.data);
+            removePoll(pollId);
         });
 
         eventSource.addEventListener("chat_delete", (e) => {
@@ -453,6 +512,15 @@
         <SafeMarkdown source={data.stream.description} />
     {/if}
 </div>
+
+<StreamPolls
+    streamId={data.stream.id}
+    {polls}
+    canManage={Boolean(isOwnerOrAdmin)}
+    canVote={Boolean(data.user && data.user.isVerified && !data.user.isBanned)}
+    onLocalUpdate={(poll) => mergePoll(poll, false)}
+    onLocalDelete={removePoll}
+/>
 
 <StreamChatList
     streamId={data.stream.id}

--- a/src/routes/live/[id]/[chatId]/+server.ts
+++ b/src/routes/live/[id]/[chatId]/+server.ts
@@ -20,6 +20,12 @@ import { json, error } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { StreamChat, Stream } from "$lib/server/database";
 import { streamingService } from "$lib/server/streaming";
+import {
+    InvalidReactionError,
+    deleteReactionsFor,
+    toggleReaction,
+} from "$lib/server/reactions";
+import { ReactionTargetType } from "$lib/types";
 
 export const DELETE: RequestHandler = async (event) => {
     const user = event.locals.user;
@@ -42,6 +48,67 @@ export const DELETE: RequestHandler = async (event) => {
     }
 
     await chat.destroy();
+    await deleteReactionsFor(ReactionTargetType.streamChat, chat.id);
     streamingService.notifyChatDeleted(stream.id, chat.id);
     return json({ success: true });
+};
+
+/**
+ * Toggles the caller's reaction on a chat message. This also works after the
+ * stream is archived, so the chat history on the audio page stays interactive.
+ */
+export const POST: RequestHandler = async (event) => {
+    const user = event.locals.user;
+    if (!user) {
+        return json({ message: "You must be logged in" }, { status: 401 });
+    }
+    if (user.isBanned) {
+        return json({ message: "You are banned" }, { status: 403 });
+    }
+    if (!user.isVerified) {
+        return json(
+            { message: "Please verify your email before reacting" },
+            { status: 403 },
+        );
+    }
+
+    const chatId = event.params.chatId;
+    if (!chatId) {
+        return json({ message: "Missing chat ID" }, { status: 400 });
+    }
+
+    const chat = await StreamChat.findByPk(chatId, { include: Stream });
+    if (!chat) {
+        return json({ message: "Not found" }, { status: 404 });
+    }
+
+    let body: any;
+    try {
+        body = await event.request.json();
+    } catch {
+        return json({ message: "Invalid request" }, { status: 400 });
+    }
+
+    try {
+        const reactions = await toggleReaction(
+            user.id,
+            ReactionTargetType.streamChat,
+            chat.id,
+            body?.emoji,
+        );
+        const mine = reactions.find((r) => r.reacted)?.emoji ?? null;
+        streamingService.notifyChatReaction(
+            chat.streamId,
+            chat.id,
+            reactions,
+            user.id,
+            mine,
+        );
+        return json({ reactions });
+    } catch (err) {
+        if (err instanceof InvalidReactionError) {
+            return json({ message: "Unknown reaction" }, { status: 400 });
+        }
+        throw err;
+    }
 };

--- a/src/routes/live/[id]/events/+server.ts
+++ b/src/routes/live/[id]/events/+server.ts
@@ -27,6 +27,8 @@ import {
     STREAM_ARCHIVED,
     STREAM_MODERATION_CHANGED,
     STREAM_CHAT_REACTION,
+    STREAM_POLL_CHANGED,
+    STREAM_POLL_DELETED,
 } from "$lib/server/streaming";
 import type {
     StreamStateChangedEvent,
@@ -36,6 +38,8 @@ import type {
     StreamArchivedEvent,
     StreamModerationChangedEvent,
     StreamChatReactionEvent,
+    StreamPollChangedEvent,
+    StreamPollDeletedEvent,
 } from "$lib/server/streaming";
 
 export const GET: RequestHandler = async (event) => {
@@ -97,6 +101,18 @@ export const GET: RequestHandler = async (event) => {
         }
     };
 
+    const onPollChanged = (data: StreamPollChangedEvent) => {
+        if (data.streamId === stream.id) {
+            send("poll", { kind: data.kind, poll: data.poll });
+        }
+    };
+
+    const onPollDeleted = (data: StreamPollDeletedEvent) => {
+        if (data.streamId === stream.id) {
+            send("poll_delete", { pollId: data.pollId });
+        }
+    };
+
     const onModerationChanged = (data: StreamModerationChangedEvent) => {
         if (data.streamId === stream.id) {
             send("moderation", {
@@ -142,6 +158,8 @@ export const GET: RequestHandler = async (event) => {
             streamingService.on(STREAM_ARCHIVED, onArchived);
             streamingService.on(STREAM_MODERATION_CHANGED, onModerationChanged);
             streamingService.on(STREAM_CHAT_REACTION, onChatReaction);
+            streamingService.on(STREAM_POLL_CHANGED, onPollChanged);
+            streamingService.on(STREAM_POLL_DELETED, onPollDeleted);
 
             keepalive = setInterval(() => {
                 try {
@@ -161,6 +179,8 @@ export const GET: RequestHandler = async (event) => {
             streamingService.off(STREAM_ARCHIVED, onArchived);
             streamingService.off(STREAM_MODERATION_CHANGED, onModerationChanged);
             streamingService.off(STREAM_CHAT_REACTION, onChatReaction);
+            streamingService.off(STREAM_POLL_CHANGED, onPollChanged);
+            streamingService.off(STREAM_POLL_DELETED, onPollDeleted);
             streamingService.listenerDisconnected(stream.id);
         },
     });

--- a/src/routes/live/[id]/events/+server.ts
+++ b/src/routes/live/[id]/events/+server.ts
@@ -26,6 +26,7 @@ import {
     STREAM_CHAT_DELETED,
     STREAM_ARCHIVED,
     STREAM_MODERATION_CHANGED,
+    STREAM_CHAT_REACTION,
 } from "$lib/server/streaming";
 import type {
     StreamStateChangedEvent,
@@ -34,6 +35,7 @@ import type {
     StreamChatDeletedEvent,
     StreamArchivedEvent,
     StreamModerationChangedEvent,
+    StreamChatReactionEvent,
 } from "$lib/server/streaming";
 
 export const GET: RequestHandler = async (event) => {
@@ -84,6 +86,17 @@ export const GET: RequestHandler = async (event) => {
         }
     };
 
+    const onChatReaction = (data: StreamChatReactionEvent) => {
+        if (data.streamId === stream.id) {
+            send("chat_reaction", {
+                chatId: data.chatId,
+                reactions: data.reactions,
+                actorId: data.actorId,
+                emoji: data.emoji,
+            });
+        }
+    };
+
     const onModerationChanged = (data: StreamModerationChangedEvent) => {
         if (data.streamId === stream.id) {
             send("moderation", {
@@ -128,6 +141,7 @@ export const GET: RequestHandler = async (event) => {
             streamingService.on(STREAM_CHAT_DELETED, onChatDeleted);
             streamingService.on(STREAM_ARCHIVED, onArchived);
             streamingService.on(STREAM_MODERATION_CHANGED, onModerationChanged);
+            streamingService.on(STREAM_CHAT_REACTION, onChatReaction);
 
             keepalive = setInterval(() => {
                 try {
@@ -146,6 +160,7 @@ export const GET: RequestHandler = async (event) => {
             streamingService.off(STREAM_CHAT_DELETED, onChatDeleted);
             streamingService.off(STREAM_ARCHIVED, onArchived);
             streamingService.off(STREAM_MODERATION_CHANGED, onModerationChanged);
+            streamingService.off(STREAM_CHAT_REACTION, onChatReaction);
             streamingService.listenerDisconnected(stream.id);
         },
     });

--- a/src/routes/live/[id]/polls/+server.ts
+++ b/src/routes/live/[id]/polls/+server.ts
@@ -1,0 +1,89 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2024 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import { Stream } from "$lib/server/database";
+import { streamingService } from "$lib/server/streaming";
+import {
+    PollValidationError,
+    createPoll,
+    getPollsForStream,
+    serializePoll,
+    serializePollForBroadcast,
+} from "$lib/server/polls";
+import { StreamState } from "$lib/types";
+
+export const GET: RequestHandler = async (event) => {
+    const stream = await Stream.findByPk(event.params.id);
+    if (!stream) {
+        return json({ message: "Stream not found" }, { status: 404 });
+    }
+    const user = event.locals.user;
+    const isHost = Boolean(user && (user.id === stream.userId || user.isAdmin));
+    return json({
+        polls: await getPollsForStream(stream.id, user?.id, isHost),
+    });
+};
+
+/** Only the broadcaster and admins run polls. */
+export const POST: RequestHandler = async (event) => {
+    const user = event.locals.user;
+    if (!user) {
+        return json({ message: "You must be logged in" }, { status: 401 });
+    }
+
+    const stream = await Stream.findByPk(event.params.id);
+    if (!stream) {
+        return json({ message: "Stream not found" }, { status: 404 });
+    }
+    if (user.id !== stream.userId && !user.isAdmin) {
+        return json({ message: "Not authorized" }, { status: 403 });
+    }
+
+    if (stream.state === StreamState.finished) {
+        return json({ message: "Stream has ended" }, { status: 400 });
+    }
+
+    let body: any;
+    try {
+        body = await event.request.json();
+    } catch {
+        return json({ message: "Invalid request" }, { status: 400 });
+    }
+
+    try {
+        const poll = await createPoll(stream.id, user.id, {
+            question: body?.question ?? "",
+            options: body?.options,
+            allowMultiple: body?.allowMultiple,
+            hideResultsUntilVote: body?.hideResultsUntilVote,
+        });
+        streamingService.notifyPollChanged(
+            stream.id,
+            "created",
+            await serializePollForBroadcast(poll),
+        );
+        return json({ poll: await serializePoll(poll, user.id, true) });
+    } catch (err) {
+        if (err instanceof PollValidationError) {
+            return json({ message: err.message }, { status: 400 });
+        }
+        throw err;
+    }
+};

--- a/src/routes/live/[id]/polls/[pollId]/+server.ts
+++ b/src/routes/live/[id]/polls/[pollId]/+server.ts
@@ -1,0 +1,147 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2024 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import { Stream } from "$lib/server/database";
+import { streamingService } from "$lib/server/streaming";
+import {
+    PollValidationError,
+    castVote,
+    closePoll,
+    findPoll,
+    serializePoll,
+    serializePollForBroadcast,
+} from "$lib/server/polls";
+import { PollState } from "$lib/types";
+
+/** Votes: one per user per poll, changeable while the poll is open. */
+export const POST: RequestHandler = async (event) => {
+    const user = event.locals.user;
+    if (!user) {
+        return json({ message: "You must be logged in to vote" }, { status: 401 });
+    }
+    if (user.isBanned) {
+        return json({ message: "You are banned" }, { status: 403 });
+    }
+    if (!user.isVerified) {
+        return json(
+            { message: "Please verify your email before voting" },
+            { status: 403 },
+        );
+    }
+
+    const stream = await Stream.findByPk(event.params.id);
+    if (!stream) {
+        return json({ message: "Stream not found" }, { status: 404 });
+    }
+    const isHost = user.id === stream.userId || user.isAdmin;
+
+    const poll = await findPoll(event.params.pollId, event.params.id);
+    if (!poll) {
+        return json({ message: "Poll not found" }, { status: 404 });
+    }
+
+    let body: any;
+    try {
+        body = await event.request.json();
+    } catch {
+        return json({ message: "Invalid request" }, { status: 400 });
+    }
+
+    const optionId = body?.optionId;
+    if (typeof optionId !== "string" || !optionId) {
+        return json({ message: "Missing option" }, { status: 400 });
+    }
+
+    try {
+        const updated = await castVote(poll, user.id, optionId);
+        if (!updated) {
+            // Re-picking the same option changes nothing; report the current
+            // tally so the client stays in sync anyway.
+            return json({ poll: await serializePoll(poll, user.id, isHost) });
+        }
+        streamingService.notifyPollChanged(
+            poll.streamId,
+            "updated",
+            await serializePollForBroadcast(updated),
+        );
+        return json({ poll: await serializePoll(updated, user.id, isHost) });
+    } catch (err) {
+        if (err instanceof PollValidationError) {
+            return json({ message: err.message }, { status: 400 });
+        }
+        throw err;
+    }
+};
+
+/** Closes a poll, freezing its result for the archive. */
+export const PUT: RequestHandler = async (event) => {
+    const user = event.locals.user;
+    if (!user) {
+        return json({ message: "You must be logged in" }, { status: 401 });
+    }
+
+    const stream = await Stream.findByPk(event.params.id);
+    if (!stream) {
+        return json({ message: "Stream not found" }, { status: 404 });
+    }
+    if (user.id !== stream.userId && !user.isAdmin) {
+        return json({ message: "Not authorized" }, { status: 403 });
+    }
+
+    const poll = await findPoll(event.params.pollId, stream.id);
+    if (!poll) {
+        return json({ message: "Poll not found" }, { status: 404 });
+    }
+    if (poll.state === PollState.closed) {
+        return json({ poll: await serializePoll(poll, user.id, true) });
+    }
+
+    const closed = await closePoll(poll);
+    streamingService.notifyPollChanged(
+        stream.id,
+        "closed",
+        await serializePollForBroadcast(closed),
+    );
+    return json({ poll: await serializePoll(closed, user.id, true) });
+};
+
+export const DELETE: RequestHandler = async (event) => {
+    const user = event.locals.user;
+    if (!user) {
+        return json({ message: "You must be logged in" }, { status: 401 });
+    }
+
+    const stream = await Stream.findByPk(event.params.id);
+    if (!stream) {
+        return json({ message: "Stream not found" }, { status: 404 });
+    }
+    if (user.id !== stream.userId && !user.isAdmin) {
+        return json({ message: "Not authorized" }, { status: 403 });
+    }
+
+    const poll = await findPoll(event.params.pollId, stream.id);
+    if (!poll) {
+        return json({ message: "Poll not found" }, { status: 404 });
+    }
+
+    await poll.destroy();
+    streamingService.notifyPollDeleted(stream.id, poll.id);
+    return json({ success: true });
+};

--- a/src/routes/upload/+page.server.ts
+++ b/src/routes/upload/+page.server.ts
@@ -20,15 +20,30 @@ import fs from "fs/promises";
 import path from "path";
 import { error, fail, redirect } from "@sveltejs/kit";
 import type { Actions, PageServerLoad } from "./$types";
-import { Audio, Notification, Subscription } from "$lib/server/database";
+import { Audio, Notification, Subscription, User } from "$lib/server/database";
 import transcode from "$lib/server/transcode";
 import { NotificationTargetType, NotificationType } from "$lib/types";
 
-export const load: PageServerLoad = (event) => {
+export const load: PageServerLoad = async (event) => {
     const user = event.locals.user;
     if (!user) {
         return redirect(303, "/login");
     }
+
+    // Admin notices are pinned above the form so uploaders read them before
+    // submitting anything.
+    const announcements = await Audio.findAll({
+        where: { isAnnouncement: true, hasFile: true },
+        include: [User],
+        order: [["createdAt", "DESC"]],
+    });
+
+    return {
+        announcements: announcements.map((audio) => ({
+            ...audio.toClientside(),
+            mimeType: audio.mimeType,
+        })),
+    };
 };
 
 export const actions: Actions = {
@@ -59,6 +74,9 @@ export const actions: Actions = {
         const file = form.get("file") as File;
         const title = form.get("title") as string;
         const description = form.get("description") as string;
+        // Only admins may pin an audio; the checkbox is not rendered for others
+        // and is ignored here even if it is forged.
+        const isAnnouncement = user.isAdmin && form.get("isAnnouncement") === "on";
         if (!file) {
             return fail(400, { title, description });
         }
@@ -81,6 +99,7 @@ export const actions: Actions = {
             hasFile: true,
             userId: user.id,
             extension: path.extname(file.name),
+            isAnnouncement,
         });
         await fs.writeFile(audio.path, Buffer.from(await file.arrayBuffer()));
         transcode(audio.path).catch(async (err) => {

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -20,11 +20,41 @@
     import { enhance } from "$app/forms";
     import title from "$lib/title";
     import { onMount } from "svelte";
+    import AudioPlayer from "$lib/components/audio_player.svelte";
+    import SafeMarkdown from "$lib/components/safe_markdown.svelte";
+
+    export let data;
+
     onMount(() => title.set("Upload Audio"));
     let submitting = false;
+
+    $: announcements = data.announcements ?? [];
 </script>
 
 <h1>Upload Audio</h1>
+
+{#if announcements.length > 0}
+    <section class="announcements" aria-label="Announcements from the administrators">
+        <h2>Please read before uploading</h2>
+        {#each announcements as announcement (announcement.id)}
+            <article class="announcement">
+                <h3>
+                    <a href="/listen/{announcement.id}">{announcement.title}</a>
+                </h3>
+                <AudioPlayer
+                    preload="none"
+                    sources={[
+                        { src: `/${announcement.path}`, type: announcement.mimeType },
+                        { src: `/${announcement.transcodedPath}`, type: "audio/aac" },
+                    ]}
+                />
+                {#if announcement.description}
+                    <SafeMarkdown source={announcement.description} />
+                {/if}
+            </article>
+        {/each}
+    </section>
+{/if}
 
 <form
     use:enhance={() => {
@@ -87,6 +117,21 @@
         Please follow common decency and the law. Moderators and admins reserve
         the right to remove any content that is deemed inappropriate or illegal.
     </p>
+    {#if data.isAdmin}
+        <div class="form-group">
+            <!-- A switch rather than a plain checkbox, and still a real form
+                 control so the upload works without JavaScript. -->
+            <label class="announcement-toggle" for="isAnnouncement">
+                <input
+                    type="checkbox"
+                    role="switch"
+                    id="isAnnouncement"
+                    name="isAnnouncement"
+                />
+                Pin this audio as an announcement at the top of this page
+            </label>
+        </div>
+    {/if}
     <button type="submit" class="btn" disabled={submitting}
         >{#if submitting}Uploading...{:else}Upload{/if}</button
     >
@@ -151,6 +196,39 @@
         margin: 0.35rem 0 0;
         font-size: 0.85rem;
         color: #666;
+    }
+
+    .announcements {
+        max-width: 600px;
+        margin: 0 auto 1.5rem;
+        padding: 1rem;
+        border: 1px solid #ffeeba;
+        border-radius: 8px;
+        background-color: #fff3cd;
+        color: #856404;
+    }
+
+    .announcements h2 {
+        margin-top: 0;
+        font-size: 1.1rem;
+    }
+
+    .announcement + .announcement {
+        margin-top: 1rem;
+        padding-top: 1rem;
+        border-top: 1px solid #ffeeba;
+    }
+
+    .announcement h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1rem;
+    }
+
+    .announcement-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-weight: normal;
     }
 
     .btn {


### PR DESCRIPTION
## Summary

- Let stream owners and admins run polls during a live stream, up to three open at a time
- Two options per poll: allow several picks instead of one, and keep the tally hidden until the viewer has voted
- Broadcast poll changes over SSE, and keep polls readable on the audio page once the stream is archived

## Notes

Hidden results are zeroed server side rather than merely hidden by the UI, so the answer cannot be read off the network response. The SSE broadcast reaches every listener, so it never carries a hidden tally nor any per viewer state; clients entitled to the numbers refetch their own view. A hidden tally opens up once the poll closes, and is always visible to the host.

Percentages use distinct voters as the denominator, so a multiple choice poll does not add up past 100%.

## Stacked on #33

This branch is based on #33, which is based on #32, so its diff currently includes both of those commits. I will rebase as they are resolved. Marked as a draft until then.

## Validation

- `npm run check` — 0 errors and 0 warnings
- `npm run build`
- Migration applied and rolled back
- Single and multiple choice polls, hidden and visible results, voting, vote switching and closing exercised with two accounts

Part of #35
