### PR TITLE
Move the hardcoded audiopub.site addresses into environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ MAILGUN_API_KEY=
 MAILGUN_DOMAIN=
 # The JWT secret. This is used to sign the JWT tokens.
 JWT_SECRET=
+# The public base URL of this instance, without a trailing slash. Used to build links in emails, such as the password reset link. Defaults to `https://audiopub.site`.
+BASE_URL=https://audiopub.site
 # The backup directory.
 BACKUP_DIR=
 # The size limit for the body of the request. This is used to prevent large requests from being sent to the server. Please note that this does not directly govern the maximum size for audio uploads. For that, you will need to change it from the code.

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ ICECAST_HOST=127.0.0.1:8000
 ICECAST_ADMIN_USER=
 # The password for the icecast admin user.
 ICECAST_ADMIN_PASSWORD=
+# The base URL listeners play streams from, without a trailing slash. Unlike `ICECAST_HOST`, this is the address of the icecast server as seen from the outside. Defaults to `https://live.audiopub.site`.
+PUBLIC_STREAM_LISTEN_URL=https://live.audiopub.site
+# The host and port broadcasting software connects to in order to send audio. Shown on the streaming instructions page. Defaults to `live.audiopub.site` and `8000`.
+PUBLIC_STREAM_INGEST_HOST=live.audiopub.site
+PUBLIC_STREAM_INGEST_PORT=8000
 
 
 # The API key for OneSignal.

--- a/src/lib/server/database/models/user.ts
+++ b/src/lib/server/database/models/user.ts
@@ -45,6 +45,11 @@ if (!process.env.JWT_SECRET) {
     throw new Error("JWT_SECRET is not defined");
 }
 
+const baseUrl = (process.env.BASE_URL || "https://audiopub.site").replace(
+    /\/+$/,
+    "",
+);
+
 export interface UserInfo {
     id: string;
     name: string;
@@ -232,7 +237,7 @@ export default class User extends Model {
     async generateResetPasswordToken() {
         this.resetPasswordToken = v4();
         await this.save();
-        const resetUrl = `https://audiopub.site/reset_password/${this.resetPasswordToken}`;
+        const resetUrl = `${baseUrl}/reset_password/${this.resetPasswordToken}`;
         // Send email.
         await sendEmail(
             this.email,

--- a/src/lib/server/database/models/user.ts
+++ b/src/lib/server/database/models/user.ts
@@ -45,6 +45,7 @@ if (!process.env.JWT_SECRET) {
     throw new Error("JWT_SECRET is not defined");
 }
 
+// The public URL of this instance, used to build the links we put in emails.
 const baseUrl = (process.env.BASE_URL || "https://audiopub.site").replace(
     /\/+$/,
     "",

--- a/src/lib/streaming_config.ts
+++ b/src/lib/streaming_config.ts
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2026 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { env } from "$env/dynamic/public";
+
+// The public address of the icecast server, as seen by listeners and by
+// broadcasters. This is not the same as `ICECAST_HOST`, which is the address
+// the server itself uses to reach icecast, and is usually not reachable from
+// the outside.
+
+// Base URL listeners play a stream from. The mount point, which is the user
+// id, is appended to it.
+export const streamListenUrl = (
+    env.PUBLIC_STREAM_LISTEN_URL || "https://live.audiopub.site"
+).replace(/\/+$/, "");
+
+// Host and port broadcasting software sends audio to.
+export const streamIngestHost =
+    env.PUBLIC_STREAM_INGEST_HOST || "live.audiopub.site";
+export const streamIngestPort = env.PUBLIC_STREAM_INGEST_PORT || "8000";

--- a/src/routes/live/[id]/+page.svelte
+++ b/src/routes/live/[id]/+page.svelte
@@ -28,6 +28,7 @@
     import { fade, slide } from "svelte/transition";
     import { enhance } from "$app/forms";
     import title from "$lib/title";
+    import { streamListenUrl } from "$lib/streaming_config";
     import type {
         ClientsideStreamChat,
         ClientsideStreamMute,
@@ -249,7 +250,7 @@
         const IcecastMetadataPlayer = (await import("icecast-metadata-player"))
             .default;
         player = new IcecastMetadataPlayer(
-            `https://live.audiopub.site/${data.stream.user?.id}`,
+            `${streamListenUrl}/${data.stream.user?.id}`,
             {
                 audioElement: audioEl,
                 playbackMethod: iOS() ? "html5" : undefined,

--- a/src/routes/stream/instructions/+page.svelte
+++ b/src/routes/stream/instructions/+page.svelte
@@ -19,6 +19,10 @@
 <script lang="ts">
     import { enhance } from "$app/forms";
     import title from "$lib/title";
+    import {
+        streamIngestHost,
+        streamIngestPort,
+    } from "$lib/streaming_config";
     import { onMount } from "svelte";
 
     export let data;
@@ -27,9 +31,11 @@
 
     let showSensitiveInfo = false;
 
+    const ingestAddress = `${streamIngestHost}:${streamIngestPort}`;
+
     $: icecastUrl =
         data.user?.streamKey && showSensitiveInfo
-            ? `icecast://source:${data.user.streamKey}@live.audiopub.site:8000/${data.user.id}`
+            ? `icecast://source:${data.user.streamKey}@${ingestAddress}/${data.user.id}`
             : null;
 
     const placeholderKey = "<your-stream-key>";
@@ -97,12 +103,12 @@
     <dl>
         <dt>Server address</dt>
         <dd>
-            <code>live.audiopub.site</code>
+            <code>{streamIngestHost}</code>
         </dd>
 
         <dt>Port</dt>
         <dd>
-            <code>8000</code>
+            <code>{streamIngestPort}</code>
         </dd>
 
         <dt>Mount point</dt>
@@ -152,7 +158,7 @@
             <code class="sensitive full-url">{icecastUrl}</code>
         {:else}
             <code class="sensitive masked full-url">
-                icecast://source:{placeholderKey}@live.audiopub.site:8000/{placeholderUserId}
+                icecast://source:{placeholderKey}@{ingestAddress}/{placeholderUserId}
             </code>
         {/if}
     </p>
@@ -211,7 +217,7 @@
             <code class="sensitive full-url">{icecastUrl}</code>
         {:else}
             <code class="sensitive masked full-url">
-                icecast://source:{placeholderKey}@live.audiopub.site:8000/{placeholderUserId}
+                icecast://source:{placeholderKey}@{ingestAddress}/{placeholderUserId}
             </code>
         {/if}
     </p>


### PR DESCRIPTION
## Problem

Three places had an audiopub.site address written into them, so any deployment that isn't the production site behaved incorrectly:

- `generateResetPasswordToken` in `src/lib/server/database/models/user.ts` built the password reset link from `https://audiopub.site`, so users of another instance were emailed a link into production, where their token isn't valid.
- The live stream page connected the player to `https://live.audiopub.site/<user id>`, so the play button on any other instance streamed production's audio.
- The streaming instructions page told broadcasters to send their audio to `live.audiopub.site` on port 8000, in the connection details and in the two full `icecast://` URLs.

## Change

- New `BASE_URL` for the site's own public URL, read with `process.env` alongside the other server-side variables. A trailing slash is stripped so `https://example.com/` and `https://example.com` both give a well-formed link.
- New `PUBLIC_STREAM_LISTEN_URL`, `PUBLIC_STREAM_INGEST_HOST` and `PUBLIC_STREAM_INGEST_PORT` for the public address of the icecast server, collected in a small `$lib/streaming_config` module that both pages import.
- Every variable falls back to the value that was previously hardcoded, so existing deployments keep working with no configuration change.
- All four are documented in `.env.example`.

## Notes

- The stream variables are read through `$env/dynamic/public` rather than `$env/static/public`. Static would make the defaults impossible, since a missing variable is a build error, and it would bake the values into the bundle so that changing them means rebuilding. `$lib/streaming_config` is where the defaults live, so pages import from it rather than reading the environment directly.
- These are deliberately separate from `ICECAST_HOST`. That one is the address the server uses to reach icecast, which defaults to `127.0.0.1:8000` and is usually not reachable from the outside, so it can't double as the address given to listeners and broadcasters.
- Verified with `npx svelte-check` (0 errors, 0 warnings) and `npm run build`.

Testing and documentation assisted with [Claude Code](https://claude.com/claude-code)