### PR TITLE
Fix listener counts drifting upward on live streams

### DIFF
--- a/src/lib/server/streaming.ts
+++ b/src/lib/server/streaming.ts
@@ -39,6 +39,7 @@ export class StreamingService extends EventEmitter {
     private icecastAdminPassword: string = "";
     private timer: ReturnType<typeof setInterval> | null = null;
     private archiveControllers: Map<string, AbortController> = new Map();
+    private streamListeners: Map<string, Set<object>> = new Map();
 
     constructor(pollIntervalMs: number = 5 * 60 * 1000) {
         super();
@@ -413,14 +414,34 @@ export class StreamingService extends EventEmitter {
         }
     }
 
-    async listenerConnected(streamId: string) {
+    async listenerConnected(streamId: string, listener: object) {
+        let listeners = this.streamListeners.get(streamId);
+        if (!listeners) {
+            listeners = new Set();
+            this.streamListeners.set(streamId, listeners);
+        }
+        if (listeners.has(listener)) return;
+        listeners.add(listener);
+
+        await this.publishListeners(streamId, listeners.size);
+    }
+
+    async listenerDisconnected(streamId: string, listener: object) {
+        const listeners = this.streamListeners.get(streamId);
+        if (!listeners?.delete(listener)) return;
+        if (listeners.size === 0) {
+            this.streamListeners.delete(streamId);
+        }
+
+        await this.publishListeners(streamId, listeners.size);
+    }
+
+    private async publishListeners(streamId: string, activeListeners: number) {
         await Stream.update(
             {
-                activeListeners: Stream.sequelize!.literal(
-                    "activeListeners + 1",
-                ),
+                activeListeners,
                 peekListeners: Stream.sequelize!.literal(
-                    "GREATEST(peekListeners, activeListeners + 1)",
+                    `GREATEST(peekListeners, ${activeListeners})`,
                 ),
             },
             { where: { id: streamId } },
@@ -436,32 +457,6 @@ export class StreamingService extends EventEmitter {
             updated.activeListeners,
             updated.peekListeners,
         );
-    }
-
-    async listenerDisconnected(streamId: string) {
-        const [updated] = await Stream.update(
-            {
-                activeListeners: Stream.sequelize!.literal(
-                    "activeListeners - 1",
-                ),
-            },
-            {
-                where: { id: streamId, activeListeners: { [Op.gt]: 0 } },
-            },
-        );
-
-        if (updated) {
-            const updatedStream = await Stream.findByPk(streamId, {
-                attributes: ["activeListeners", "peekListeners"],
-            });
-            if (updatedStream) {
-                this.notifyListenersChanged(
-                    streamId,
-                    updatedStream.activeListeners,
-                    updatedStream.peekListeners,
-                );
-            }
-        }
     }
 
     async disconnectSource(userId: string) {

--- a/src/routes/live/[id]/events/+server.ts
+++ b/src/routes/live/[id]/events/+server.ts
@@ -45,8 +45,6 @@ export const GET: RequestHandler = async (event) => {
         return new Response(null, { status: 204 });
     }
 
-    streamingService.listenerConnected(stream.id);
-
     const encoder = new TextEncoder();
 
     const onStateChanged = (data: StreamStateChangedEvent) => {
@@ -59,6 +57,7 @@ export const GET: RequestHandler = async (event) => {
                 } catch {
                     /* already closed */
                 }
+                cleanup();
             }
         }
     };
@@ -105,11 +104,32 @@ export const GET: RequestHandler = async (event) => {
 
     let controllerRef: ReadableStreamDefaultController | null = null;
 
+    const listener = {};
+
     function send(eventName: string, data: unknown) {
         if (!controllerRef) return;
         const payload = `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`;
-        controllerRef.enqueue(encoder.encode(payload));
+        try {
+            controllerRef.enqueue(encoder.encode(payload));
+        } catch {
+            controllerRef = null;
+            cleanup();
+        }
     }
+
+    // A client can go away without cancel() firing, so everything that notices
+    // ends up here. Calling it more than once is harmless
+    const cleanup = () => {
+        clearInterval(keepalive ?? undefined);
+        keepalive = null;
+        streamingService.off(STREAM_STATE_CHANGED, onStateChanged);
+        streamingService.off(STREAM_LISTENERS_CHANGED, onListenersChanged);
+        streamingService.off(STREAM_CHAT_SENT, onChatSent);
+        streamingService.off(STREAM_CHAT_DELETED, onChatDeleted);
+        streamingService.off(STREAM_ARCHIVED, onArchived);
+        streamingService.off(STREAM_MODERATION_CHANGED, onModerationChanged);
+        streamingService.listenerDisconnected(stream.id, listener);
+    };
 
     const stream2 = new ReadableStream({
         start(controller) {
@@ -129,26 +149,22 @@ export const GET: RequestHandler = async (event) => {
             streamingService.on(STREAM_ARCHIVED, onArchived);
             streamingService.on(STREAM_MODERATION_CHANGED, onModerationChanged);
 
+            streamingService.listenerConnected(stream.id, listener);
+
             keepalive = setInterval(() => {
                 try {
                     controllerRef?.enqueue(encoder.encode(": keepalive\n\n"));
                 } catch {
-                    clearInterval(keepalive ?? undefined);
-                    keepalive = null;
+                    cleanup();
                 }
             }, 30000);
         },
         cancel() {
-            clearInterval(keepalive ?? undefined);
-            streamingService.off(STREAM_STATE_CHANGED, onStateChanged);
-            streamingService.off(STREAM_LISTENERS_CHANGED, onListenersChanged);
-            streamingService.off(STREAM_CHAT_SENT, onChatSent);
-            streamingService.off(STREAM_CHAT_DELETED, onChatDeleted);
-            streamingService.off(STREAM_ARCHIVED, onArchived);
-            streamingService.off(STREAM_MODERATION_CHANGED, onModerationChanged);
-            streamingService.listenerDisconnected(stream.id);
+            cleanup();
         },
     });
+
+    event.request.signal.addEventListener("abort", cleanup);
 
     return new Response(stream2, {
         headers: {


### PR DESCRIPTION
`activeListeners` is a stored counter, not a measurement. `live/[id]/events/+server.ts` adds one per SSE connection (`listenerConnected` -> `activeListeners + 1`) and takes one away only if that connection's `cancel()` handler runs. Any close the server does not observe is therefore a listener that stays on the row for the rest of the stream, and because the value lives in the database it survives everything except the reset in `StreamingService.start()`. `peekListeners` is a `GREATEST(...)` over the same value, so it ratchets too, and it becomes the archived audio's `plays`.

Several ordinary things produce a close the server does not observe:

- A half-open socket (mobile network change, NAT idle drop). No FIN, no RST, so neither the response stream nor the request signal ever fires, and `enqueue` into a dead socket does not throw for a long time - the write just fills a buffer.
- `EventSource` reconnects. The listener page's `onerror` deliberately lets the browser retry; every retry is another `listenerConnected`, and the ghost it is replacing may still be counted.
- The keepalive's `catch` (a dead client, reliably) cleared the interval and returned without calling `listenerDisconnected`.
- The `finished` transition, which calls `controllerRef.close()`. A producer closing the stream never invokes `cancel()`, so those listeners were never subtracted at all.

Because a client cannot be identified across connections, the count only ever grows. Anecdotally a broadcaster watching from a source client sees the number climb through a long stream while chat stays quiet.

### The change

**Count what is open instead of accumulating deltas.** `StreamingService` keeps a `Map<string, Set<object>>` of live connections; `listenerConnected`/`listenerDisconnected` take a per-connection token, and both publish `set.size` through a new `publishListeners` that writes the count and re-reads the row to notify. Nothing increments or decrements a stored value any more, so a missed close costs one listener for as long as that one dead connection sits in the set rather than for the rest of the stream, a stale row corrects itself on the next connect or disconnect, and a restart starts from an empty map. `GREATEST(peekListeners, ...)` is kept, now over the true count.

**Unregister from every path that can notice.** `+server.ts` grows one idempotent `cleanup()` - clear the keepalive, `off` the six subscriptions, unregister the connection - called from `cancel()`, from `event.request.signal`'s `abort` (adapter-node aborts it on client disconnect, and it fires in cases the response-stream cancel does not), from the keepalive `catch`, from the `finished` close, and from a new `try`/`catch` around `send()`'s `enqueue`.

That last one is worth its own line: `send()` was calling `enqueue` unguarded from inside `streamingService.emit(...)`. Enqueueing on a closed or errored controller throws, and because `EventEmitter.emit` runs its handlers synchronously, one stale connection could throw partway through the handler list - so later subscribers never received the event and the throw propagated back into whatever called `notifyStateChanged`, e.g. `sourceConnected` or `endStream`. Now a failing enqueue only retires the connection it belongs to.

No schema change, no migration, no API change. `peekListeners` and the `plays` value derived from it are unaffected except that they no longer ratchet on ghosts.

### What this does not fix

A genuinely half-open connection still occupies a slot until Node's write finally errors. Killing those needs client liveness (a ping endpoint plus a sweeper on `lastSeen`), which touches the listener page and third-party source clients, so it is not in here. This change is what stops the error from being permanent.

### Testing

`npm run check` is clean. I have no MariaDB/Icecast environment for this project, so nothing here has been run against a live stream.
