### PR TITLE
Shareable /live/@username stream links

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -20,7 +20,20 @@
 // for information about these interfaces
 declare global {
 	namespace App {
-		// interface Error {}
+		interface Error {
+			message: string;
+			/*
+			 * Set by the /live/@username lookup so its error page can say which
+			 * of the two things went wrong -- no such account, or an account
+			 * that simply is not broadcasting -- and link somewhere useful
+			 * instead of showing a bare 404.
+			 */
+			live?: {
+				reason: "no_user" | "not_live";
+				userName: string;
+				displayName?: string;
+			};
+		}
 		// interface Locals {}
 		// interface PageData {}
 		// interface PageState {}

--- a/src/lib/live_links.ts
+++ b/src/lib/live_links.ts
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2026 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * The shape of the shareable live link, /live/@username, kept apart from the
+ * lookup that resolves it. Pages have to build one of these to show it to a
+ * broadcaster, and that runs in the browser -- so the string half lives out
+ * here where client code may import it, and only the database half sits in
+ * $lib/server/live_links.
+ *
+ * The "@" follows the convention /user/[id] already uses for profiles, so
+ * /live/@alice reads the same way as /user/@alice.
+ */
+
+/** Marks a /live/... segment as a username rather than a stream id. */
+export const USERNAME_PREFIX = "@";
+
+export function isUsernameParam(param: string): boolean {
+    return param.startsWith(USERNAME_PREFIX);
+}
+
+/** The shareable path for a broadcaster, e.g. "/live/@alice". */
+export function liveUsernamePath(userName: string): string {
+    return `/live/${USERNAME_PREFIX}${encodeURIComponent(userName)}`;
+}

--- a/src/lib/server/live_links.ts
+++ b/src/lib/server/live_links.ts
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the audiopub project.
+ *
+ * Copyright (C) 2026 the-byte-bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * The stable, shareable form of a live link: /live/@alice instead of
+ * /live/<uuid>. A broadcaster can only have one unfinished stream at a time
+ * (enforced in /live/new), so the name is enough to identify "whatever they are
+ * broadcasting right now" -- which means the link survives from one broadcast
+ * to the next and can sit in a bio or a signature unchanged.
+ *
+ * The "@" is what keeps this from colliding with the uuid links that listeners
+ * already hold: a uuid can never start with one, so the same [id] route can
+ * tell the two apart without a lookup, and the old links keep resolving exactly
+ * as they did.
+ */
+import { Op } from "sequelize";
+import { Stream, User } from "$lib/server/database";
+import { StreamState } from "$lib/types";
+import { USERNAME_PREFIX } from "$lib/live_links";
+
+export type LiveUsernameResolution =
+    /** The account exists and has a stream that has not finished. */
+    | { kind: "live"; streamId: string; userName: string; displayName: string }
+    /** No account by that name. */
+    | { kind: "no_user"; userName: string }
+    /** The account exists but is not broadcasting at the moment. */
+    | { kind: "not_live"; userName: string; displayName: string };
+
+/**
+ * Resolves the "@username" form of a /live/[id] parameter to the broadcaster's
+ * current stream. Takes the parameter with its "@" still attached, as it
+ * arrives from the router.
+ */
+export async function resolveLiveUsername(
+    param: string,
+): Promise<LiveUsernameResolution> {
+    // Names are stored lowercase (User.normalizeData), so the link is
+    // case-insensitive without the caller having to think about it.
+    const userName = param.slice(USERNAME_PREFIX.length).toLowerCase();
+    if (!userName) {
+        return { kind: "no_user", userName };
+    }
+
+    const user = await User.findOne({ where: { name: userName } });
+    if (!user) {
+        return { kind: "no_user", userName };
+    }
+
+    /*
+     * Every state but "finished" counts as current -- the same test /live/new
+     * and the profile page use. A stream sitting in "pending" or "disconnected"
+     * is one whose page is still worth showing: the source may not have
+     * connected yet, or may be on its way back.
+     *
+     * Ordered newest-first purely as a belt-and-braces measure. There should
+     * only ever be one row here, but if a stale one ever survives, the link
+     * should lead to the broadcast that is actually going on.
+     */
+    const stream = await Stream.findOne({
+        where: {
+            userId: user.id,
+            state: { [Op.ne]: StreamState.finished },
+        },
+        order: [["createdAt", "DESC"]],
+    });
+
+    if (!stream) {
+        return {
+            kind: "not_live",
+            userName: user.name,
+            displayName: user.displayName,
+        };
+    }
+
+    return {
+        kind: "live",
+        streamId: stream.id,
+        userName: user.name,
+        displayName: user.displayName,
+    };
+}

--- a/src/routes/live/[id]/+error.svelte
+++ b/src/routes/live/[id]/+error.svelte
@@ -1,0 +1,147 @@
+<!--
+  This file is part of the audiopub project.
+
+  Copyright (C) 2026 the-byte-bender
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
+  Scoped to /live/[id] on purpose. What lands here is almost always a shared
+  /live/@username link that did not lead anywhere: the page load attaches a
+  "live" object to the error saying which of the two cases it is, so the reader
+  gets a way onwards instead of a bare 404.
+-->
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { page } from "$app/stores";
+    import title from "$lib/title";
+
+    $: live = $page.error?.live;
+    $: userName = live?.userName ?? "";
+    $: displayName = live?.displayName || userName;
+
+    $: heading =
+        live?.reason === "not_live"
+            ? `${displayName} is not live`
+            : live?.reason === "no_user"
+              ? "No such account"
+              : "Nothing to listen to here";
+
+    // The search page rejects anything shorter than three characters, so a
+    // badly mistyped name gets the profile link only.
+    $: canSearch = userName.length >= 3;
+
+    onMount(() => title.set(heading));
+</script>
+
+<div class="not-live">
+    <h1>{heading}</h1>
+
+    {#if live?.reason === "not_live"}
+        <p>
+            There is no broadcast running on this account at the moment. It may
+            have just ended, or it may not have started yet.
+        </p>
+        <p class="tip">
+            Keep the link anyway: <code>/live/@{userName}</code> always leads to
+            whatever this person has on the air, so it will bring you straight
+            there next time they go live.
+        </p>
+        <div class="actions">
+            <a class="btn" href="/user/@{encodeURIComponent(userName)}">
+                View {displayName}'s profile
+            </a>
+            <a class="btn btn-secondary" href="/">Back to the home page</a>
+        </div>
+    {:else if live?.reason === "no_user"}
+        <p>
+            There is no account called <code>{userName}</code>. The link most
+            likely has a typo in it.
+        </p>
+        <div class="actions">
+            {#if canSearch}
+                <a class="btn" href="/search?q={encodeURIComponent(userName)}">
+                    Search for "{userName}"
+                </a>
+            {/if}
+            <a class="btn btn-secondary" href="/">Back to the home page</a>
+        </div>
+    {:else}
+        <p>{$page.error?.message ?? "Something went wrong."}</p>
+        <div class="actions">
+            <a class="btn" href="/">Back to the home page</a>
+        </div>
+    {/if}
+</div>
+
+<style>
+    .not-live {
+        max-width: 40rem;
+        margin: 2rem auto;
+        padding: 1.5rem;
+        border: 1px solid #e0e0e0;
+        border-radius: 6px;
+        background-color: #fafafa;
+    }
+
+    h1 {
+        margin-top: 0;
+        font-size: 1.5rem;
+    }
+
+    p {
+        line-height: 1.5;
+        color: #444;
+    }
+
+    .tip {
+        font-size: 0.9rem;
+        color: #666;
+    }
+
+    code {
+        background-color: #eee;
+        border-radius: 3px;
+        padding: 0.1rem 0.3rem;
+        font-size: 0.9em;
+    }
+
+    .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 1.5rem;
+    }
+
+    .btn {
+        display: inline-block;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        background-color: #007bff;
+        color: #fff;
+        text-decoration: none;
+    }
+
+    .btn:hover {
+        background-color: #0056b3;
+    }
+
+    .btn-secondary {
+        background-color: #6c757d;
+    }
+
+    .btn-secondary:hover {
+        background-color: #545b62;
+    }
+</style>

--- a/src/routes/live/[id]/+page.server.ts
+++ b/src/routes/live/[id]/+page.server.ts
@@ -27,8 +27,39 @@ import { error, redirect } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 import { Op } from "sequelize";
 import type { ClientsideStreamMute } from "$lib/types";
+import { isUsernameParam } from "$lib/live_links";
+import { resolveLiveUsername } from "$lib/server/live_links";
 
 export const load: PageServerLoad = async (event) => {
+    /*
+     * "@username" is the shareable alias for whatever this account is
+     * broadcasting right now; it redirects to the uuid link rather than
+     * rendering here, so there stays exactly one canonical page per stream and
+     * the chat, SSE and moderation endpoints -- which all address a stream by
+     * id -- need no changes. Checked before the findByPk below because a name
+     * is not a stream id and would simply miss.
+     */
+    if (isUsernameParam(event.params.id)) {
+        const resolved = await resolveLiveUsername(event.params.id);
+        if (resolved.kind === "live") {
+            return redirect(302, `/live/${resolved.streamId}`);
+        }
+        if (resolved.kind === "not_live") {
+            return error(404, {
+                message: `${resolved.displayName} is not broadcasting right now.`,
+                live: {
+                    reason: "not_live",
+                    userName: resolved.userName,
+                    displayName: resolved.displayName,
+                },
+            });
+        }
+        return error(404, {
+            message: "There is no account with that name.",
+            live: { reason: "no_user", userName: resolved.userName },
+        });
+    }
+
     const stream = await Stream.findByPk(event.params.id, {
         include: [
             User,

--- a/src/routes/stream/instructions/+page.server.ts
+++ b/src/routes/stream/instructions/+page.server.ts
@@ -31,6 +31,7 @@ export const load: PageServerLoad = async (event) => {
         return {
             user: {
                 id: user.id,
+                name: user.name,
                 streamKey: user.streamKey,
             },
         };

--- a/src/routes/stream/instructions/+page.svelte
+++ b/src/routes/stream/instructions/+page.svelte
@@ -23,6 +23,8 @@
         streamIngestHost,
         streamIngestPort,
     } from "$lib/streaming_config";
+    import { liveUsernamePath } from "$lib/live_links";
+    import { page } from "$app/stores";
     import { onMount } from "svelte";
 
     export let data;
@@ -41,6 +43,15 @@
     const placeholderKey = "<your-stream-key>";
     $: placeholderUserId = data.user?.id ?? "<your-user-id>";
     $: hasUser = data.user !== null;
+
+    /*
+     * Built from the origin the page was actually served on rather than from a
+     * configured base URL, so an instance reachable under more than one name
+     * hands out a link that works from where the broadcaster is standing.
+     */
+    $: shareUrl = data.user
+        ? `${$page.url.origin}${liveUsernamePath(data.user.name)}`
+        : `${$page.url.origin}/live/@<your-username>`;
 </script>
 
 <h1>How to Stream to audiopub</h1>
@@ -66,6 +77,33 @@
         is like a password. You can find your stream key on your
         <a href="/profile">Profile page</a>. If you have not set a stream key
         yet, you can generate one there.
+    </p>
+</section>
+
+<section>
+    <h2>Your Stream Link</h2>
+
+    <p>
+        Whatever you are broadcasting is always reachable at the link below. It
+        is tied to your name rather than to any one stream, so it stays the same
+        every time you go live, and it is safe to put in a bio or a signature.
+    </p>
+
+    <p class="url-display">
+        {#if hasUser}
+            <code class="full-url">{shareUrl}</code>
+        {:else}
+            <code class="full-url masked">
+                {shareUrl} (log in to see your stream link)
+            </code>
+        {/if}
+    </p>
+
+    <p>
+        Anyone who opens it lands on your live page, with the player and the
+        chat. If you are not broadcasting at the time, it tells them so rather
+        than leading nowhere. This link is not sensitive; unlike the URLs
+        further down this page, it does not contain your stream key.
     </p>
 </section>
 


### PR DESCRIPTION
## The problem

A live stream is only addressable by the uuid of that one broadcast. The link a
broadcaster shares goes dead the moment the stream ends, so it has to be shared
afresh every single time they go live — which rules out putting it in a bio, a
signature, or a pinned post.

## The change

`/live/@alice` resolves to whatever that account is broadcasting at the moment
it is opened. The link stays the same across broadcasts, so it is worth pinning
somewhere.

This follows the convention `/user/[id]` already uses for profiles, so
`/live/@alice` reads the same way as `/user/@alice`.

**Existing links are untouched.** A uuid can never start with `@`, so the same
`[id]` route tells the two forms apart with a string check and no extra lookup.
Anything already holding a uuid link resolves exactly as before.

**A username 302s onto the canonical uuid page** rather than rendering in place.
That keeps exactly one page per stream, and means the chat, SSE and moderation
endpoints — which all address a stream by id — need no changes at all. It is
deliberately a 302 and not a 301: the target legitimately changes with each
broadcast, so it must not be cached.

**Resolution is unambiguous** because `/live/new` already enforces one
unfinished stream per user, so "the account's current stream" is a single row.
The lookup treats every state but `finished` as current — the same test
`/live/new` and the profile page already use — so a stream sitting in `pending`
or `disconnected` still resolves. Names are matched lowercased, matching
`User.normalizeData`, so the link is case-insensitive.

**When the link leads nowhere**, a route-scoped `+error.svelte` distinguishes
the two cases instead of showing a bare 404:

- *no such account* — most likely a typo; offers search and home.
- *not broadcasting right now* — says so plainly, and tells the reader the link
  is still worth keeping, since it will work next time that person goes live.
  Links to their profile.

**Discoverability**: the streaming instructions page now shows broadcasters
their own link. It is built from `page.url.origin` rather than a configured base
URL, so it needs no new environment variable and an instance reachable under
more than one hostname hands out a link that works from wherever the
broadcaster is standing.

## Files

| File | What |
|---|---|
| `src/lib/live_links.ts` | The link's string form. Client-importable, no DB. |
| `src/lib/server/live_links.ts` | `resolveLiveUsername` — the DB half. |
| `src/routes/live/[id]/+page.server.ts` | Dispatch on `@` before the uuid lookup. |
| `src/routes/live/[id]/+error.svelte` | The "leads nowhere" page. |
| `src/app.d.ts` | `App.Error` gains the optional `live` object the error page reads. |
| `src/routes/stream/instructions/+page.{svelte,server.ts}` | Shows the broadcaster their link. |

## Notes for review

- `pnpm check` (`svelte-check`) is clean: 0 errors, 0 warnings.
- I could not exercise this against a running instance with a live Icecast
  source, so the runtime paths — particularly the redirect and the two error
  cases — deserve a look from someone who can. The logic is small and
  self-contained, but I would rather flag that than imply it has been smoke
  tested.
- I have unit tests for `resolveLiveUsername` and the link helpers, but the repo
  has no test runner today and adding one felt like a separate decision that doesn't belong in this PR.